### PR TITLE
lock the version of rustc to 1.74.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build CI
 on: [push, pull_request]
 
 env:
-  rust-toolchain: nightly
+  rust-toolchain: nightly-2023-09-01
 
 jobs:
   clippy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build & Deploy docs
 on: [push, pull_request]
 
 env:
-  rust-toolchain: nightly
+  rust-toolchain: nightly-2023-09-01
 
 jobs:
   doc:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   qemu-version: 7.1.0
-  rust-toolchain: nightly
+  rust-toolchain: nightly-2023-09-01
 
 jobs:
   unit-test:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly"
+channel = "nightly-2023-09-01"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat"]


### PR DESCRIPTION
I lock the version of rustc to 1.74.0(nightly-2023-09-01) to pass the CI.