### PR TITLE
Add module `ax9p` for 9pfs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "ax9p"
+version = "0.1.0"
+dependencies = [
+ "axdriver",
+ "axfs",
+ "axfs_vfs",
+ "axnet",
+ "driver_9p",
+ "driver_common",
+ "log",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "axalloc"
 version = "0.1.0"
 dependencies = [
@@ -291,6 +305,7 @@ dependencies = [
  "axconfig",
  "axhal",
  "cfg-if",
+ "driver_9p",
  "driver_block",
  "driver_common",
  "driver_display",
@@ -311,6 +326,7 @@ dependencies = [
 name = "axfeat"
 version = "0.1.0"
 dependencies = [
+ "ax9p",
  "axalloc",
  "axdisplay",
  "axdriver",
@@ -460,6 +476,7 @@ dependencies = [
 name = "axruntime"
 version = "0.1.0"
 dependencies = [
+ "ax9p",
  "axalloc",
  "axconfig",
  "axdisplay",
@@ -881,6 +898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "driver_9p"
+version = "0.1.0"
+dependencies = [
+ "driver_common",
+ "log",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "driver_block"
 version = "0.1.0"
 dependencies = [
@@ -921,10 +947,13 @@ dependencies = [
 name = "driver_virtio"
 version = "0.1.0"
 dependencies = [
+ "driver_9p",
  "driver_block",
  "driver_common",
  "driver_display",
  "driver_net",
+ "log",
+ "spin 0.9.8",
  "virtio-drivers",
 ]
 
@@ -1999,7 +2028,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.4.0"
-source = "git+https://github.com/rcore-os/virtio-drivers.git?rev=409ee72#409ee723c92adf309e825a7b87f53049707ed306"
+source = "git+https://github.com/syswonder/virtio-drivers.git?rev=256ec4c#256ec4ca669a40719090aeaec858f707e8259183"
 dependencies = [
  "bitflags 1.3.2",
  "log",

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,18 @@
 #     - `BLK`: Enable storage devices (virtio-blk)
 #     - `NET`: Enable network devices (virtio-net)
 #     - `GRAPHIC`: Enable display devices and graphic output (virtio-gpu)
+#     - `V9P`: Enable virtio-9p devices
 #     - `BUS`: Device bus type: mmio, pci
 #     - `DISK_IMG`: Path to the virtual disk image
 #     - `ACCEL`: Enable hardware acceleration (KVM on linux)
 #     - `QEMU_LOG`: Enable QEMU logging (log file is "qemu.log")
 #     - `NET_DUMP`: Enable network packet dump (log file is "netdump.pcap")
 #     - `NET_DEV`: QEMU netdev backend types: user, tap
+# * 9P options:
+#     - `V9P_PATH`: Host path for backend of virtio-9p
+#     - `NET_9P_ADDR`: Server address and port for 9P netdev 
+#     - `ANAME_9P`: Path for root of 9pfs(parameter of TATTACH for root)
+#     - `PROTOCOL_9P`: Default protocol version selected for 9P
 # * Network options:
 #     - `IP`: ArceOS IPv4 address (default is 10.0.2.15 for QEMU user netdev)
 #     - `GW`: Gateway IPv4 address (default is 10.0.2.2 for QEMU user netdev)
@@ -44,12 +50,18 @@ APP_FEATURES ?=
 BLK ?= n
 NET ?= n
 GRAPHIC ?= n
+V9P ?= n
 BUS ?= mmio
+
 
 DISK_IMG ?= disk.img
 QEMU_LOG ?= n
 NET_DUMP ?= n
 NET_DEV ?= user
+V9P_PATH ?= ./
+NET_9P_ADDR ?= 127.0.0.1:564
+ANAME_9P ?= ./
+PROTOCOL_9P ?= 9P2000.L
 
 # Network options
 IP ?= 10.0.2.15
@@ -121,6 +133,9 @@ export AX_LOG=$(LOG)
 export AX_TARGET=$(TARGET)
 export AX_IP=$(IP)
 export AX_GW=$(GW)
+export AX_9P_ADDR = $(NET_9P_ADDR)
+export AX_ANAME_9P = $(ANAME_9P)
+export AX_PROTOCOL_9P = $(PROTOCOL_9P)
 
 # Binutils
 CROSS_COMPILE ?= $(ARCH)-linux-musl-

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -41,6 +41,7 @@ sched_cfs = ["axtask/sched_cfs", "irq"]
 # File system
 fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
 myfs = ["axfs?/myfs"]
+9pfs = []
 
 # Networking
 net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet", "axruntime/net"]
@@ -50,6 +51,10 @@ display = ["alloc", "paging", "axdriver/virtio-gpu", "dep:axdisplay", "axruntime
 
 # Signal
 signal = ["axruntime/signal"]
+
+# 9P
+virtio-9p = ["9pfs", "axdriver/virtio-9p", "ax9p/virtio-9p", "axruntime/virtio-9p"]
+net-9p = ["9pfs", "net", "ax9p/net-9p", "axruntime/net-9p"]
 
 # Device drivers
 bus-mmio = ["axdriver?/bus-mmio"]
@@ -73,6 +78,7 @@ axlog = { path = "../../modules/axlog" }
 axalloc = { path = "../../modules/axalloc", optional = true }
 axdriver = { path = "../../modules/axdriver", optional = true }
 axfs = { path = "../../modules/axfs", optional = true }
+ax9p = { path = "../../modules/ax9p", optional = true }
 axnet = { path = "../../modules/axnet", optional = true }
 axdisplay = { path = "../../modules/axdisplay", optional = true }
 axsync = { path = "../../modules/axsync", optional = true }

--- a/apps/c/filetest/main.c
+++ b/apps/c/filetest/main.c
@@ -24,12 +24,12 @@ int main() {
 	fd= open("filetest/a.txt", O_RDWR);
     fp = fdopen(fd, "r");
     fgets(s, 50, fp);
-	if(strcmp("1 2 3 4", s)) {
+	if(strcmp("1 2 3 4\n", s)) {
 		perror("fdopen and freopen failed");
 		return -1;
 	}
     fgets(s, 50, fp);
-	if(strcmp("5 6 7 8", s)) {
+	if(strcmp("5 6 7 8\n", s)) {
 		perror("fdopen and freopen failed");
 		return -1;
 	}

--- a/apps/c/redis/README.md
+++ b/apps/c/redis/README.md
@@ -13,7 +13,17 @@
      ```
      make A=apps/c/redis/ LOG=error NET=y BLK=y ARCH=x86_64 SMP=4 ARGS="./redis-server,--bind,0.0.0.0,--port,5555,--save,\"\",--appendonly,no,--protected-mode,no" run
      ```
-  
+
+  - version 3 for aarch64(using 9pfs)
+     ```
+     make A=apps/c/redis/ LOG=error NET=y V9P=y BLK=y V9P_PATH=apps/c/redis ARCH=aarch64 SMP=4 ARGS="./redis-server,/v9fs/redis.conf" run
+     ```  
+
+  - version 3 for x86_64(using 9pfs)
+     ```
+     make A=apps/c/redis/ LOG=error NET=y V9P=y BLK=y V9P_PATH=apps/c/redis ARCH=x86_64 SMP=4 ARGS="./redis-server,/v9fs/redis.conf" run
+     ```  
+
 
 # How to test?
 - Use `redis-cli -p 5555` to connect to redis-server, and enjoy ArceOS-Redis world!
@@ -342,3 +352,4 @@ LRANGE_500 (first 450 elements): 16485.33 requests per second
 LRANGE_600 (first 600 elements): 13159.63 requests per second
 MSET (10 keys): 72780.20 requests per second
 ```
+

--- a/apps/c/redis/features.txt
+++ b/apps/c/redis/features.txt
@@ -8,3 +8,4 @@ net
 pipe
 epoll
 poll
+virtio-9p

--- a/apps/c/redis/redis.conf
+++ b/apps/c/redis/redis.conf
@@ -1,0 +1,6 @@
+bind 0.0.0.0
+port 5555
+protected-mode no
+save "" 
+appendonly no
+ignore-warnings ARM64-COW-BUG

--- a/apps/fs/shell/Cargo.toml
+++ b/apps/fs/shell/Cargo.toml
@@ -14,4 +14,4 @@ default = []
 axfs_vfs = { path = "../../../crates/axfs_vfs", optional = true }
 axfs_ramfs = { path = "../../../crates/axfs_ramfs", optional = true }
 crate_interface = { path = "../../../crates/crate_interface", optional = true }
-axstd = { path = "../../../ulib/axstd", features = ["alloc", "fs"], optional = true }
+axstd = { path = "../../../ulib/axstd", features = ["alloc", "fs", "virtio-9p"], optional = true }

--- a/crates/driver_9p/Cargo.toml
+++ b/crates/driver_9p/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "driver_9p"
+version = "0.1.0"
+edition = "2021"
+authors = ["Zheng Wu <hello_weekday@163.com>"]
+description = "Common traits and types for block storage drivers"
+license = "GPL-3.0-or-later OR Apache-2.0"
+homepage = "https://github.com/rcore-os/arceos"
+repository = "https://github.com/rcore-os/arceos/tree/main/crates/driver_common"
+documentation = "https://rcore-os.github.io/arceos/driver_common/index.html"
+
+[features]
+default = []
+
+[dependencies]
+log = "0.4"
+spin = "0.9"
+driver_common = { path = "../driver_common" }

--- a/crates/driver_9p/src/lib.rs
+++ b/crates/driver_9p/src/lib.rs
@@ -1,0 +1,26 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+//! Common traits and types for 9P device drivers (i.e. 9P2000.L, 9P2000.U).
+
+#![no_std]
+#![feature(doc_auto_cfg)]
+#![feature(const_trait_impl)]
+
+#[doc(no_inline)]
+pub use driver_common::BaseDriverOps;
+
+/// Operations that require a 9p driver to implement.
+pub trait _9pDriverOps: BaseDriverOps {
+    /// initialize self(e.g. setup TCP connection)
+    fn init(&self) -> Result<(), u8>;
+
+    /// send bytes of inputs as request and receive  get answer in outputs
+    fn send_with_recv(&mut self, inputs: &[u8], outputs: &mut [u8]) -> Result<u32, u8>; // Ok(length)/Err()
+}

--- a/crates/driver_common/src/lib.rs
+++ b/crates/driver_common/src/lib.rs
@@ -36,6 +36,8 @@ pub enum DeviceType {
     Net,
     /// Graphic display device (e.g., GPU)
     Display,
+    /// Plan-9 device (e.g. 9pfs)
+    _9P,
 }
 
 /// The error type for device operation failures.

--- a/crates/driver_pci/Cargo.toml
+++ b/crates/driver_pci/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/rcore-os/arceos/tree/main/crates/driver_pci"
 documentation = "https://rcore-os.github.io/arceos/driver_pci/index.html"
 
 [dependencies]
-virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "409ee72" }
+virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "256ec4c"}

--- a/crates/driver_virtio/Cargo.toml
+++ b/crates/driver_virtio/Cargo.toml
@@ -13,10 +13,14 @@ documentation = "https://rcore-os.github.io/arceos/driver_virtio/index.html"
 block = ["driver_block"]
 net = ["driver_net"]
 gpu = ["driver_display"]
+v9p = ["driver_9p"]
 
 [dependencies]
+log = "0.4"
+spin = "0.9"
 driver_common = { path = "../driver_common" }
 driver_block = { path = "../driver_block", optional = true }
 driver_net = { path = "../driver_net", optional = true }
 driver_display = { path = "../driver_display", optional = true}
-virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "409ee72" }
+driver_9p = { path = "../driver_9p", optional = true}
+virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "256ec4c" }

--- a/crates/driver_virtio/src/lib.rs
+++ b/crates/driver_virtio/src/lib.rs
@@ -29,6 +29,8 @@ mod blk;
 mod gpu;
 #[cfg(feature = "net")]
 mod net;
+#[cfg(feature = "v9p")]
+mod v9p;
 
 #[cfg(feature = "block")]
 pub use self::blk::VirtIoBlkDev;
@@ -36,6 +38,8 @@ pub use self::blk::VirtIoBlkDev;
 pub use self::gpu::VirtIoGpuDev;
 #[cfg(feature = "net")]
 pub use self::net::VirtIoNetDev;
+#[cfg(feature = "v9p")]
+pub use self::v9p::VirtIo9pDev;
 
 pub use virtio_drivers::transport::pci::bus as pci;
 pub use virtio_drivers::transport::{mmio::MmioTransport, pci::PciTransport, Transport};
@@ -84,6 +88,7 @@ const fn as_dev_type(t: VirtIoDevType) -> Option<DeviceType> {
         Block => Some(DeviceType::Block),
         Network => Some(DeviceType::Net),
         GPU => Some(DeviceType::Display),
+        _9P => Some(DeviceType::_9P),
         _ => None,
     }
 }

--- a/crates/driver_virtio/src/v9p.rs
+++ b/crates/driver_virtio/src/v9p.rs
@@ -1,0 +1,52 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+use driver_9p::_9pDriverOps;
+use driver_common::{BaseDriverOps, DevResult, DeviceType};
+use virtio_drivers::{device::v9p::VirtIO9p as InnerDev, transport::Transport, Hal};
+
+/// The VirtIO 9p device driver.
+pub struct VirtIo9pDev<H: Hal, T: Transport> {
+    inner: InnerDev<H, T>,
+}
+
+unsafe impl<H: Hal, T: Transport> Send for VirtIo9pDev<H, T> {}
+unsafe impl<H: Hal, T: Transport> Sync for VirtIo9pDev<H, T> {}
+
+impl<H: Hal, T: Transport> VirtIo9pDev<H, T> {
+    /// Creates a new driver instance and initializes the device, or returns
+    /// an error if any step fails.
+    pub fn try_new(transport: T) -> DevResult<Self> {
+        Ok(Self {
+            inner: InnerDev::new(transport).unwrap(),
+        })
+    }
+}
+
+impl<H: Hal, T: Transport> const BaseDriverOps for VirtIo9pDev<H, T> {
+    fn device_name(&self) -> &str {
+        "virtio-9p"
+    }
+
+    fn device_type(&self) -> DeviceType {
+        DeviceType::_9P
+    }
+}
+
+impl<H: Hal, T: Transport> _9pDriverOps for VirtIo9pDev<H, T> {
+    // initialize self(e.g. setup TCP connection)
+    fn init(&self) -> Result<(), u8> {
+        Ok(())
+    }
+
+    // send bytes of inputs as request and receive  get answer in outputs
+    fn send_with_recv(&mut self, inputs: &[u8], outputs: &mut [u8]) -> Result<u32, u8> {
+        self.inner.request(inputs, outputs)
+    }
+}

--- a/modules/ax9p/Cargo.toml
+++ b/modules/ax9p/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ax9p"
+version = "0.1.0"
+edition = "2021"
+authors = ["Zheng Wu <hello_weekday@163.com>"]
+description = "RukOS Plan-9 filesystem module"
+license = "GPL-3.0-or-later OR Apache-2.0"
+homepage = "https://github.com/rcore-os/rukos"
+repository = "https://github.com/rcore-os/rukos/tree/main/modules/ax9p"
+documentation = "https://rcore-os.github.io/rukos/ax9p/index.html"
+
+[features]
+virtio-9p = ["axdriver/virtio-9p", "axdriver/virtio-9p"]
+net-9p = ["axnet", "driver_common", "axdriver/dyn" , "axdriver/_9p"]
+need_auth = []
+
+[dependencies]
+log = "0.4"
+spin = "0.9"
+driver_9p = { path = "../../crates/driver_9p"}
+axfs_vfs = { path = "../../crates/axfs_vfs"}
+driver_common = { path = "../../crates/driver_common", optional = true}
+
+axfs = { path = "../axfs"}
+axnet = { path = "../axnet", optional = true}
+axdriver = { path = "../axdriver"}

--- a/modules/ax9p/src/drv.rs
+++ b/modules/ax9p/src/drv.rs
@@ -1,0 +1,1061 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+#![allow(clippy::identity_op)]
+#![allow(dead_code)]
+
+use alloc::{string::String, string::ToString, sync::Arc, vec, vec::Vec};
+use axdriver::prelude::*;
+use log::*;
+use spin::RwLock;
+
+const UNDEFINED_ERROR: u8 = 0;
+const _9P_LEAST_QLEN: u32 = 7; // size[4] type_id[1] tag[2]
+const _9P_MAX_QSIZE: u32 = 8192 + 1; // it should larger than 8192, or virtio-9p may raise a warning.
+const _9P_MAX_PSIZE: u32 = 8192 + 1; // it should larger than 8192, or virtio-9p may raise a warning.
+const _9P_NONUNAME: u32 = 0;
+
+pub const _9P_SETATTR_MODE: u64 = 0x00000001;
+pub const _9P_SETATTR_UID: u64 = 0x00000002;
+pub const _9P_SETATTR_GID: u64 = 0x00000004;
+pub const _9P_SETATTR_SIZE: u64 = 0x00000008;
+pub const _9P_SETATTR_ATIME: u64 = 0x00000010;
+pub const _9P_SETATTR_MTIME: u64 = 0x00000020;
+pub const _9P_SETATTR_CTIME: u64 = 0x00000040;
+pub const _9P_SETATTR_ATIME_SET: u64 = 0x00000080;
+pub const _9P_SETATTR_MTIME_SET: u64 = 0x00000100;
+
+const FID_MAX: u32 = 4096;
+
+pub struct Drv9pOps {
+    transport: Arc<RwLock<Ax9pDevice>>,
+    fid_gen: RwLock<Vec<u32>>,
+}
+
+impl Drv9pOps {
+    pub fn new(transport: Ax9pDevice) -> Self {
+        match transport.init() {
+            Ok(_) => {
+                info!("9p dev init success");
+            }
+            Err(ecode) => {
+                error!("9p dev init fail! error code:{}", ecode);
+            }
+        }
+        Self {
+            transport: Arc::new(RwLock::new(transport)),
+            fid_gen: RwLock::new((0..=FID_MAX).rev().collect::<Vec<u32>>()),
+        }
+    }
+
+    // Send request and receive response
+    pub fn request(&mut self, request: &[u8], response: &mut [u8]) -> Result<(), u8> {
+        let enqueue_try = self.transport.write().send_with_recv(request, response);
+        match enqueue_try {
+            Ok(_) => {
+                const RTYPE_INDEX: usize = 4;
+                const ECODE_INDEX: usize = 7;
+                const ERROR_RESP: u8 = _9PType::Rlerror as u8;
+                match response[RTYPE_INDEX] {
+                    ERROR_RESP => {
+                        error!(
+                            "9pfs request occurs a error, errcode: {}",
+                            response[ECODE_INDEX]
+                        );
+                        Err(response[ECODE_INDEX])
+                    }
+                    _ => Ok(()),
+                }
+            }
+            Err(_) => Err(UNDEFINED_ERROR),
+        }
+    }
+
+    /// get a new unique fid from uid pool.
+    pub fn get_fid(&mut self) -> Option<u32> {
+        let mut fid_gen = self.fid_gen.write();
+        fid_gen.pop()
+    }
+
+    /// recycle a fid for the use of next fops.
+    pub fn recycle_fid(&mut self, id: u32) {
+        let mut fid_gen = self.fid_gen.write();
+        if fid_gen.contains(&id) {
+            warn!("fid {} already exist", id);
+        } else {
+            fid_gen.push(id);
+        }
+    }
+
+    /// The Terror implement in 9P2000.L, Terror is usually not needed(So it is not implement).
+    pub fn l_terror(&mut self, ecode: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tlerror);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(ecode);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tversion(&mut self, protocol: &str) -> Result<String, u8> {
+        let mut request = _9PReq::new(_9PType::Tversion);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(_9P_MAX_QSIZE);
+        // TODO: use version selected by configure
+        request.write_str(protocol);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => {
+                const START: usize = 13;
+                let length: usize =
+                    (response_buffer[12] as usize * 256) + response_buffer[11] as usize;
+                Ok(String::from_utf8_lossy(&response_buffer[START..START + length]).to_string())
+            }
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    fn tflush(&mut self, oldtag: u16) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tflush);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u16(oldtag);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tfsync(&mut self, fid: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tfsync);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tclunk(&mut self, fid: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tclunk);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tauth(&mut self, afid: u32, uname: &str, aname: &str) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tauth);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(afid);
+        request.write_str(uname);
+        request.write_str(aname);
+        request.write_u32(_9P_NONUNAME);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tattach(&mut self, fid: u32, afid: u32, uname: &str, aname: &str) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tattach);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(afid);
+        request.write_str(uname);
+        request.write_str(aname);
+        request.write_u32(_9P_NONUNAME);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn twalk(&mut self, fid: u32, newfid: u32, nwname: u16, wnames: &[&str]) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Twalk);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(newfid);
+        request.write_u16(nwname);
+        for s in wnames {
+            request.write_str(s);
+        }
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tcreate(&mut self, fid: u32, name: &str, perm: u32, mode: u8) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tcreate);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_str(name);
+        request.write_u32(perm);
+        request.write_u8(mode);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn u_tcreate(
+        &mut self,
+        fid: u32,
+        name: &str,
+        perm: u32,
+        mode: u8,
+        extension: &str,
+    ) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tcreate);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_str(name);
+        request.write_u32(perm);
+        request.write_u8(mode);
+        request.write_str(extension);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// lcreate creates a regular file name in directory fid and prepares it for I/O.
+    pub fn l_tcreate(
+        &mut self,
+        fid: u32,
+        name: &str,
+        flags: u32,
+        mode: u32,
+        gid: u32,
+    ) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tlcreate);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_str(name);
+        request.write_u32(flags);
+        request.write_u32(mode);
+        request.write_u32(gid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// This operation will eventually be replaced by renameat (see below).
+    pub fn trename(&mut self, fid: u32, dfid: u32, new_name: &str) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::TrenameAt);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(dfid);
+        request.write_str(new_name);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// Change the name of a file from oldname to newname,
+    /// possible moving it from old directory represented by olddirfid to new directory represented by newdirfid.
+    /// If the server returns ENOTSUPP, the client should fall back to the rename operation.
+    pub fn trename_at(
+        &mut self,
+        olddirfid: u32,
+        oldname: &str,
+        newdirfid: u32,
+        new_name: &str,
+    ) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::TrenameAt);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(olddirfid);
+        request.write_str(oldname);
+        request.write_u32(newdirfid);
+        request.write_str(new_name);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// open file or dir in 9P2000(.U) Operation
+    pub fn topen(&mut self, fid: u32, mode: u8) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Topen);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u8(mode);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// open file or dir in 9P2000.L Operation
+    pub fn l_topen(&mut self, fid: u32, flags: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tlopen);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(flags);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// read perform I/O on the file represented by fid.
+    /// Note that in v9fs, a read(2) or write(2) system call for a chunk of the file that won't fit in a single request is broken up into multiple requests.
+    pub fn tread(&mut self, fid: u32, offset: u64, count: u32) -> Result<Vec<u8>, u8> {
+        let mut request = _9PReq::new(_9PType::Tread);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u64(offset);
+        request.write_u32(count);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => {
+                const COUNT_START: usize = 7;
+                const COUNT_END: usize = 11;
+                let length = lbytes2u64(&response_buffer[COUNT_START..COUNT_START + 4]) as usize;
+                Ok(response_buffer[COUNT_END..COUNT_END + length].to_vec())
+            }
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    /// read directory represented by fid in 9P2000.u. In 9P2000.L, using treaddir() instead.
+    pub fn u_treaddir(&mut self, fid: u32, offset: u64, count: u32) -> Result<Vec<DirEntry>, u8> {
+        let mut request = _9PReq::new(_9PType::Tread);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u64(offset);
+        request.write_u32(count);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => {
+                const COUNT_START: usize = 7;
+                const COUNT_END: usize = 11;
+                let length: u64 = lbytes2u64(&response_buffer[COUNT_START..COUNT_START + 4]);
+
+                let mut dir_entries: Vec<DirEntry> = Vec::new();
+                let mut resp_ptr = COUNT_END;
+                while resp_ptr < length as usize {
+                    // qid[13] offset[8] type[1] name[s]
+                    let state = UStatFs::parse_u_from(&response_buffer[resp_ptr..]);
+                    let dir_entry = DirEntry {
+                        qid: state.get_qid(),
+                        offset: resp_ptr as u64,
+                        dtype: state.get_ftype(),
+                        name: state.get_name(),
+                    };
+                    resp_ptr += state.get_self_length();
+                    dir_entries.push(dir_entry);
+                }
+
+                Ok(dir_entries)
+            }
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    /// write perform I/O on the file represented by fid.
+    /// Note that in v9fs, a read(2) or write(2) system call for a chunk of the file that won't fit in a single request is broken up into multiple requests.
+    pub fn twrite(&mut self, fid: u32, offset: u64, data: &[u8]) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Twrite);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u64(offset);
+        request.write_u32(data.len() as u32);
+        for value in data {
+            request.write_u8(*value);
+        }
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tmkdir(&mut self, dfid: u32, name: &str, mode: u32, gid: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tmkdir);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(dfid);
+        request.write_str(name);
+        request.write_u32(mode);
+        request.write_u32(gid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn treaddir(&mut self, fid: u32, offset: u64, count: u32) -> Result<Vec<DirEntry>, u8> {
+        let mut request = _9PReq::new(_9PType::Treaddir);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u64(offset);
+        request.write_u32(count);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => {
+                const COUNT_START: usize = 7;
+                const COUNT_END: usize = 11;
+                let length: u64 = lbytes2u64(&response_buffer[COUNT_START..COUNT_START + 4]);
+
+                let mut dir_entries: Vec<DirEntry> = Vec::new();
+                let mut resp_ptr = COUNT_END;
+                while resp_ptr < length as usize {
+                    // qid[13] offset[8] type[1] name[s]
+                    let dir_entry = DirEntry {
+                        qid: _9PQid::new(&response_buffer[resp_ptr..resp_ptr + 13]),
+                        offset: lbytes2u64(&response_buffer[resp_ptr + 13..resp_ptr + 21]),
+                        dtype: response_buffer[resp_ptr + 21],
+                        name: lbytes2str(&response_buffer[resp_ptr + 22..]),
+                    };
+                    resp_ptr += 24 + dir_entry.name.len();
+                    dir_entries.push(dir_entry);
+                }
+
+                Ok(dir_entries)
+            }
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    pub fn tremove(&mut self, fid: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tremove);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// size[4] Rgetattr tag[2] valid[8] qid[13] mode[4] uid[4] gid[4] nlink[8] rdev[8] size[8] blksize[8] blocks[8] atime_sec[8]
+    /// atime_nsec[8] mtime_sec[8] mtime_nsec[8] ctime_sec[8] ctime_nsec[8] btime_sec[8] btime_nsec[8] gen[8] data_version[8]
+    pub fn tgetattr(&mut self, fid: u32, request_mask: u64) -> Result<FileAttr, u8> {
+        let mut request = _9PReq::new(_9PType::Tgetattr);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u64(request_mask);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => Ok(FileAttr {
+                vaild: lbytes2u64(&response_buffer[7..15]),
+                mode: lbytes2u64(&response_buffer[28..32]) as u32,
+                uid: lbytes2u64(&response_buffer[32..36]) as u32,
+                gid: lbytes2u64(&response_buffer[36..40]) as u32,
+                n_link: lbytes2u64(&response_buffer[40..48]),
+                rdev: lbytes2u64(&response_buffer[48..56]),
+                size: lbytes2u64(&response_buffer[56..64]),
+                blk_size: lbytes2u64(&response_buffer[64..72]),
+                n_blk: lbytes2u64(&response_buffer[72..80]),
+                atime_sec: lbytes2u64(&response_buffer[80..88]),
+                atime_ns: lbytes2u64(&response_buffer[88..96]),
+                mtime_sec: lbytes2u64(&response_buffer[96..104]),
+                mtime_ns: lbytes2u64(&response_buffer[104..112]),
+                ctime_sec: lbytes2u64(&response_buffer[112..120]),
+                ctime_ns: lbytes2u64(&response_buffer[120..128]),
+                btime_sec: lbytes2u64(&response_buffer[128..136]),
+                btime_ns: lbytes2u64(&response_buffer[136..144]),
+                gen: lbytes2u64(&response_buffer[144..152]),
+                date_version: lbytes2u64(&response_buffer[152..160]),
+            }),
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    pub fn tsetattr(&mut self, fid: u32, attr: FileAttr) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tsetattr);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(attr.vaild as u32);
+        request.write_u32(attr.mode);
+        request.write_u32(attr.uid);
+        request.write_u32(attr.gid);
+        request.write_u64(attr.size);
+        request.write_u64(attr.atime_sec);
+        request.write_u64(attr.atime_ns);
+        request.write_u64(attr.mtime_sec);
+        request.write_u64(attr.mtime_ns);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// xattrwalk gets a newfid pointing to xattr name. This fid can later be used to read the xattr value.
+    /// If name is NULL newfid can be used to get the list of extended attributes associated with the file system object.
+    pub fn t_xattr_walk(&mut self, fid: u32, new_fid: u32, name: &str) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::TxattrWalk);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u32(new_fid);
+        request.write_str(name);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn t_xattr_create(
+        &mut self,
+        fid: u32,
+        name: &str,
+        attr_size: u64,
+        flags: u32,
+    ) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::TxattrCreate);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_str(name);
+        request.write_u64(attr_size);
+        request.write_u32(flags);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tsymlink(&mut self, fid: u32, name: &str, symtgt: &str, gid: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tsymlink);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_str(name);
+        request.write_str(symtgt);
+        request.write_u32(gid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tmknod(
+        &mut self,
+        dfid: u32,
+        name: &str,
+        mode: u32,
+        major: u32,
+        minor: u32,
+        gid: u32,
+    ) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tmknod);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(dfid);
+        request.write_str(name);
+        request.write_u32(mode);
+        request.write_u32(major);
+        request.write_u32(minor);
+        request.write_u32(gid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn treadlink(&mut self, fid: u32) -> Result<String, u8> {
+        let mut request = _9PReq::new(_9PType::Treadlink);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => Ok(lbytes2str(&response_buffer[7..])),
+            Err(err_code) => Err(err_code),
+        }
+    }
+
+    pub fn tlink(&mut self, dfid: u32, fid: u32, name: &str) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Tlink);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(dfid);
+        request.write_u32(fid);
+        request.write_str(name);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    pub fn tunlink(&mut self, dirfid: u32, name: &str, flags: u32) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::TunlinkAT);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(dirfid);
+        request.write_str(name);
+        request.write_u32(flags);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+
+    /// create or delete a lock on a fid, similar to fcntl(F_SETLK)
+    /// bits of flags: BLOCK 1, RESERVED 1<<1;
+    /// return status if ok: SUCCESS 0; BLOCKED 1; ERROR 2; GRACE 3.  
+    pub fn tlock(&mut self, fid: u32, flags: u32, locker: PosLock) -> Result<u8, u8> {
+        let mut request = _9PReq::new(_9PType::Tlock);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u8(locker.lock_type);
+        request.write_u32(flags);
+        request.write_u64(locker.start);
+        request.write_u64(locker.length);
+        request.write_u32(locker.proc_id);
+        request.write_str(&locker.client_id);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => Ok(response_buffer[7]),
+            Err(ecode) => Err(ecode),
+        }
+    }
+
+    /// check if lock existing.
+    pub fn tgetlock(&mut self, fid: u32, locker: PosLock) -> Result<PosLock, u8> {
+        let mut request = _9PReq::new(_9PType::Tgetlock);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.write_u8(locker.lock_type);
+        request.write_u64(locker.start);
+        request.write_u64(locker.length);
+        request.write_u32(locker.proc_id);
+        request.write_str(&locker.client_id);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => Ok(PosLock {
+                lock_type: response_buffer[7],
+                start: lbytes2u64(&response_buffer[8..16]),
+                length: lbytes2u64(&response_buffer[16..24]),
+                proc_id: lbytes2u64(&response_buffer[24..28]) as u32,
+                client_id: lbytes2str(&response_buffer[28..]),
+            }),
+            Err(ecode) => Err(ecode),
+        }
+    }
+
+    /// get information of filesystem (in 9P2000.L protocol)
+    pub fn tstatfs(&mut self, fid: u32) -> Result<LStatFs, u8> {
+        let mut request = _9PReq::new(_9PType::Tstatfs);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            Ok(_) => Ok({
+                LStatFs {
+                    fs_type: lbytes2u64(&response_buffer[7..11]) as u32,
+                    blk_size: lbytes2u64(&response_buffer[11..15]) as u32,
+                    n_blk: lbytes2u64(&response_buffer[15..23]),
+                    blk_free: lbytes2u64(&response_buffer[23..31]),
+                    blk_avail: lbytes2u64(&response_buffer[31..39]),
+                    n_files: lbytes2u64(&response_buffer[39..47]),
+                    file_free: lbytes2u64(&response_buffer[47..55]),
+                    fs_id: lbytes2u64(&response_buffer[55..63]),
+                    len_name: lbytes2u64(&response_buffer[63..67]) as u32,
+                }
+            }),
+            Err(ecode) => Err(ecode),
+        }
+    }
+
+    pub fn tstat(&mut self, fid: u32) -> Result<UStatFs, u8> {
+        let mut request = _9PReq::new(_9PType::Tstat);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        request.write_u32(fid);
+        request.finish();
+        match self.request(&request.buffer, &mut response_buffer) {
+            // Note: Tstat should start stat[n] from index 7 in respone_buffer, but QEMU's start at index 9.
+            // see more at: http://ericvh.github.io/9p-rfc/rfc9p2000.u.html
+            Ok(_) => Ok(UStatFs::parse_u_from(&response_buffer[9..])),
+            Err(ecode) => Err(ecode),
+        }
+    }
+
+    pub fn twstat(&mut self, fid: u32, stat: UStatFs) -> Result<(), u8> {
+        let mut request = _9PReq::new(_9PType::Twstat);
+        let mut response_buffer: [u8; _9P_MAX_PSIZE as usize] = [0; _9P_MAX_PSIZE as usize];
+        // Note: twstat should start stat[n] from index 9 in respone_buffer, but QEMU's implement start at index 11.
+        // see more at:http://ericvh.github.io/9p-rfc/rfc9p2000.u.html
+        request.write_u16(0);
+        request.write_u32(fid);
+        request.write_u16(stat.size);
+        request.write_u16(stat.ktype);
+        request.write_u32(stat.dev);
+        request.write_u8(stat.qid.ftype);
+        request.write_u32(stat.qid.version);
+        request.write_u64(stat.qid.path);
+        request.write_u32(stat.mode);
+        request.write_u32(stat.atime);
+        request.write_u32(stat.mtime);
+        request.write_u64(stat.length);
+        request.write_str(&stat.name);
+        request.write_str(&stat.uid);
+        request.write_str(&stat.gid);
+        request.write_str(&stat.muid);
+        request.write_str(&stat.extension);
+        request.write_u32(stat.n_uid);
+        request.write_u32(stat.n_gid);
+        request.write_u32(stat.n_muid);
+        request.finish();
+        self.request(&request.buffer, &mut response_buffer)
+    }
+}
+
+fn lbytes2u64(bytes: &[u8]) -> u64 {
+    let mut ret: u64 = 0;
+    for n in bytes.iter().rev() {
+        ret = (ret << 8) + *n as u64;
+    }
+    ret
+}
+
+/// format of string in 9p: length[2] string[length]
+fn lbytes2str(bytes: &[u8]) -> String {
+    let length = lbytes2u64(&bytes[..2]) as usize;
+    let str = String::from_utf8_lossy(&bytes[2..2 + length]);
+    str.to_string()
+}
+
+struct _9PReq {
+    size: u32,
+    type_id: u8,
+    tag: u16,
+    buffer: Vec<u8>, // included size[4] type_id[1] and tag[2]
+}
+
+impl _9PReq {
+    fn new(qtype: _9PType) -> Self {
+        Self {
+            size: _9P_LEAST_QLEN,
+            type_id: qtype as u8,
+            tag: 0,
+            buffer: vec![0; 7],
+        }
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.buffer.push(value);
+    }
+
+    fn write_u16(&mut self, value: u16) {
+        self.buffer.push((value & 0xff_u16) as u8);
+        self.buffer.push(((value & 0xff00_u16) >> 8) as u8);
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        const U32_SIZE: u32 = 4;
+        let mut value = value;
+        for _ in 0..U32_SIZE {
+            let byte: u8 = (value & 0xff_u32) as u8;
+            value >>= 8;
+            self.buffer.push(byte);
+        }
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        const U64_SIZE: u32 = 8;
+        let mut value = value;
+        for _ in 0..U64_SIZE {
+            let byte: u8 = (value & 0xff_u64) as u8;
+            value >>= 8;
+            self.buffer.push(byte);
+        }
+    }
+
+    fn write_str(&mut self, value: &str) {
+        let str_size: u32 = value.as_bytes().len() as u32;
+        self.write_u16(str_size as u16);
+        for cbyte in value.bytes() {
+            self.buffer.push(cbyte);
+        }
+    }
+
+    fn finish(&mut self) {
+        const U32_SIZE: u32 = 4;
+        const TYPE_IDNEX: usize = 4;
+        const TAG_IDNEX: usize = 5;
+        let mut value = self.buffer.len() as u32;
+        for i in 0..U32_SIZE {
+            let byte = (value & 0xff_u32) as u8;
+            value >>= 8;
+            self.buffer[i as usize] = byte;
+        }
+        self.buffer[TYPE_IDNEX] = self.type_id;
+        self.buffer[TAG_IDNEX] = self.tag as u8;
+        self.buffer[TAG_IDNEX + 1] = (self.tag >> 8) as u8;
+    }
+}
+
+pub struct _9PQid {
+    ftype: u8,
+    version: u32,
+    path: u64,
+}
+
+impl _9PQid {
+    fn new(bytes: &[u8]) -> Self {
+        Self {
+            ftype: bytes[0],
+            version: lbytes2u64(&bytes[1..5]) as u32,
+            path: lbytes2u64(&bytes[5..13]),
+        }
+    }
+}
+
+pub struct PosLock {
+    lock_type: u8,
+    start: u64,
+    length: u64,
+    proc_id: u32,
+    client_id: String,
+}
+
+impl PosLock {
+    ///for lock_type: RDLCK 0, WRLCK 1, UNLCK 2    
+    pub fn new(lock_type: u8, start: u64, length: u64, proc_id: u32, client_id: &str) -> Self {
+        Self {
+            lock_type,
+            start,
+            length,
+            proc_id,
+            client_id: client_id.to_string(),
+        }
+    }
+}
+
+pub struct DirEntry {
+    qid: _9PQid,
+    offset: u64,
+    dtype: u8,
+    name: String,
+}
+
+impl DirEntry {
+    pub fn get_type(&self) -> u8 {
+        self.dtype
+    }
+
+    pub fn get_name(&self) -> &String {
+        &self.name
+    }
+}
+
+pub struct FileAttr {
+    vaild: u64,     // vaild mask
+    mode: u32,      // mode for protection
+    n_link: u64,    // number of hard links
+    uid: u32,       // user ID of owner
+    gid: u32,       // group ID of owner
+    rdev: u64,      // device ID (if special file)
+    size: u64,      // total size, in bytes
+    blk_size: u64,  // blocksize for file system I/O
+    n_blk: u64,     // number of 512B blocks allocated
+    atime_sec: u64, // time of last access
+    atime_ns: u64,
+    mtime_sec: u64, // time of last modification
+    mtime_ns: u64,
+    ctime_sec: u64, // time of last status change
+    ctime_ns: u64,
+    btime_sec: u64, // time of last create change
+    btime_ns: u64,
+    gen: u64,
+    date_version: u64,
+}
+
+impl FileAttr {
+    // TODO: add function to get/set more attributes
+    pub fn new() -> Self {
+        Self {
+            vaild: 0,
+            mode: 0,      // mode for protection
+            n_link: 0,    // number of hard links
+            uid: 0,       // user ID of owner
+            gid: 0,       // group ID of owner
+            rdev: 0,      // device ID (if special file)
+            size: 0,      // total size, in bytes
+            blk_size: 0,  // blocksize for file system I/O
+            n_blk: 0,     // number of 512B blocks allocated
+            atime_sec: 0, // time of last access
+            atime_ns: 0,
+            mtime_sec: 0, // time of last modification
+            mtime_ns: 0,
+            ctime_sec: 0, // time of last status change
+            ctime_ns: 0,
+            btime_sec: 0, // time of last create change
+            btime_ns: 0,
+            gen: 0,
+            date_version: 0,
+        }
+    }
+
+    pub fn set_size(&mut self, size: u64) {
+        self.vaild |= _9P_SETATTR_SIZE;
+        self.size = size;
+    }
+
+    pub fn get_size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn get_blk_num(&self) -> u64 {
+        self.n_blk
+    }
+}
+
+pub struct LStatFs {
+    fs_type: u32,   /* type of file system (see below) */
+    blk_size: u32,  /* optimal transfer block size */
+    n_blk: u64,     /* total data blocks in file system */
+    blk_free: u64,  /* free blocks in fs */
+    blk_avail: u64, /* free blocks avail to non-superuser */
+    n_files: u64,   /* total file nodes in file system */
+    file_free: u64, /* free file nodes in fs */
+    fs_id: u64,     /* file system id */
+    len_name: u32,  /* maximum length of filenames */
+}
+
+pub struct UStatFs {
+    size: u16,
+    ktype: u16,
+    dev: u32,
+    qid: _9PQid,
+    mode: u32,
+    atime: u32,
+    mtime: u32,
+    length: u64,
+    name: String,
+    uid: String,
+    gid: String,
+    muid: String,
+    extension: String,
+    n_uid: u32,
+    n_gid: u32,
+    n_muid: u32,
+}
+
+impl UStatFs {
+    pub fn new() -> Self {
+        Self {
+            size: 0,
+            ktype: 0,
+            dev: 0,
+            qid: _9PQid {
+                ftype: 0,
+                version: 0,
+                path: 0,
+            },
+            mode: 0,
+            atime: 0,
+            mtime: 0,
+            length: 0,
+            name: "".to_string(),
+            uid: "".to_string(),
+            gid: "".to_string(),
+            muid: "".to_string(),
+            extension: "".to_string(),
+            n_uid: 0,
+            n_gid: 0,
+            n_muid: 0,
+        }
+    }
+
+    pub fn parse_u_from(bytes: &[u8]) -> Self {
+        let name_idx = 41_usize;
+        let uid_idx = name_idx + (lbytes2u64(&bytes[name_idx..name_idx + 2]) as usize + 2);
+        let gid_idx = uid_idx + (lbytes2u64(&bytes[uid_idx..uid_idx + 2]) as usize + 2);
+        let muid_idx = gid_idx + (lbytes2u64(&bytes[gid_idx..gid_idx + 2]) as usize + 2);
+        let extension_idx = muid_idx + (lbytes2u64(&bytes[muid_idx..muid_idx + 2]) as usize + 2);
+        let extension_end =
+            extension_idx + (lbytes2u64(&bytes[extension_idx..extension_idx + 2]) as usize + 2);
+        Self {
+            size: lbytes2u64(&bytes[0..2]) as u16,
+            ktype: lbytes2u64(&bytes[2..4]) as u16,
+            dev: lbytes2u64(&bytes[4..8]) as u32,
+            qid: _9PQid::new(&bytes[8..21]),
+            mode: lbytes2u64(&bytes[21..25]) as u32,
+            atime: lbytes2u64(&bytes[25..29]) as u32,
+            mtime: lbytes2u64(&bytes[29..33]) as u32,
+            length: lbytes2u64(&bytes[33..41]),
+            name: lbytes2str(&bytes[name_idx..uid_idx]),
+            uid: lbytes2str(&bytes[uid_idx..gid_idx]),
+            gid: lbytes2str(&bytes[gid_idx..muid_idx]),
+            muid: lbytes2str(&bytes[muid_idx..extension_idx]),
+            extension: lbytes2str(&bytes[extension_idx..extension_end]),
+            n_uid: lbytes2u64(&bytes[extension_end..extension_end + 4]) as u32,
+            n_gid: lbytes2u64(&bytes[extension_end + 4..extension_end + 8]) as u32,
+            n_muid: lbytes2u64(&bytes[extension_end + 8..extension_end + 12]) as u32,
+        }
+    }
+
+    pub fn set_length(&mut self, length: u64) {
+        self.length = length;
+    }
+
+    pub fn get_length(&self) -> u64 {
+        self.length
+    }
+
+    pub fn get_blk_num(&self) -> u64 {
+        0
+    }
+
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn get_ftype(&self) -> u8 {
+        match self.qid.ftype {
+            0x00 => 0o10,
+            0x02 => 0o12,
+            0x20 => 0o6,
+            0x40 => 0o1,
+            0x80 => 0o4,
+            _ => {
+                error!("Unsupported, looking it as File(0o10)!");
+                0o10
+            }
+        }
+    }
+
+    pub fn get_qid(&self) -> _9PQid {
+        _9PQid {
+            ftype: self.qid.ftype,
+            version: self.qid.version,
+            path: self.qid.path,
+        }
+    }
+
+    pub fn get_self_length(&self) -> usize {
+        self.name.len()
+            + self.uid.len()
+            + self.gid.len()
+            + self.muid.len()
+            + self.extension.len()
+            + 63
+    }
+}
+
+enum _9PType {
+    Tlerror = 6,
+    Rlerror,
+    Tstatfs = 8,
+    Rstatfs,
+    Tlopen = 12,
+    Rlopen,
+    Tlcreate = 14,
+    Rlcreate,
+    Tsymlink = 16,
+    Rsymlink,
+    Tmknod = 18,
+    Rmknod,
+    Trename = 20,
+    Rrename,
+    Treadlink = 22,
+    Rreadlink,
+    Tgetattr = 24,
+    Rgetattr,
+    Tsetattr = 26,
+    Rsetattr,
+    TxattrWalk = 30,
+    RxattrWalk,
+    TxattrCreate = 32,
+    RxattrCreate,
+    Treaddir = 40,
+    Rreaddir,
+    Tfsync = 50,
+    Rfsync,
+    Tlock = 52,
+    Rlock,
+    Tgetlock = 54,
+    Rgetlock,
+    Tlink = 70,
+    Rlink,
+    Tmkdir = 72,
+    Rmkdir,
+    TrenameAt = 74,
+    RrenameAt,
+    TunlinkAT = 76,
+    RunlinkAT,
+    Tversion = 100,
+    Rversion,
+    Tauth = 102,
+    Rauth,
+    Tattach = 104,
+    Rattach,
+    Terror = 106,
+    Rerror,
+    Tflush = 108,
+    Rflush,
+    Twalk = 110,
+    Rwalk,
+    Topen = 112,
+    Ropen,
+    Tcreate = 114,
+    Rcreate,
+    Tread = 116,
+    Rread,
+    Twrite = 118,
+    Rwrite,
+    Tclunk = 120,
+    Rclunk,
+    Tremove = 122,
+    Rremove,
+    Tstat = 124,
+    Rstat,
+    Twstat = 126,
+    Rwstat,
+}

--- a/modules/ax9p/src/fs.rs
+++ b/modules/ax9p/src/fs.rs
@@ -1,0 +1,626 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+//! 9P filesystem used by [RukOS](https://github.com/rcore-os/arceos).
+//!
+//! The implementation is based on [`axfs_vfs`].
+use crate::drv::{self, Drv9pOps};
+use alloc::{collections::BTreeMap, string::String, string::ToString, sync::Arc, sync::Weak};
+use axfs_vfs::{
+    impl_vfs_non_dir_default, VfsDirEntry, VfsError, VfsNodeAttr, VfsNodeOps, VfsNodeRef,
+    VfsNodeType, VfsOps, VfsResult,
+};
+use log::*;
+use spin::{once::Once, RwLock};
+
+macro_rules! handle_result {
+    ($result:expr, $error_msg:expr) => {
+        match $result {
+            Ok(_) => {
+                // Handle the Ok case
+            }
+            Err(err_code) => {
+                error!($error_msg, err_code);
+            }
+        }
+    };
+}
+
+/// A 9P filesystem that implements [`axfs_vfs::VfsOps`].
+pub struct _9pFileSystem {
+    parent: Once<VfsNodeRef>,
+    root: Arc<DirNode>,
+}
+
+impl _9pFileSystem {
+    /// Create a new instance.
+    pub fn new(dev: Arc<RwLock<Drv9pOps>>, aname: &str, protocol: &str) -> Self {
+        // Initialize 9pfs version to make sure protocol is right.
+        // Select 9P2000.L at defealt first trial.
+        let mut protocol = protocol.to_string();
+        match dev.write().tversion(&protocol) {
+            Ok(protocol_server) => {
+                info!("9pfs server's protocol: {}", protocol_server);
+                if protocol != protocol_server {
+                    protocol = protocol_server;
+                }
+            }
+            Err(errcode) => {
+                error!("9pfs tversion failed! error code: {}", errcode);
+            }
+        }
+
+        // root_fid should never be recycled.
+        let fid = match dev.write().get_fid() {
+            Some(id) => id,
+            None => {
+                warn!("9pfs: No enough fids! Check fid_MAX constrant or fid leaky.");
+                0xff_ff_ff_ff
+            }
+        };
+
+        const AFID: u32 = 0xFFFF_FFFF;
+
+        // AUTH afid
+        #[cfg(feature = "need_auth")]
+        handle_result!(
+            dev.write().tauth(AFID, "rukos", "/"),
+            "9pfs auth failed! error code: {}"
+        );
+
+        // attach dir to fid
+        handle_result!(
+            dev.write().tattach(fid, AFID, "rukos", aname),
+            "9pfs attach failed! error code: {}"
+        );
+
+        Self {
+            parent: Once::new(),
+            root: DirNode::new(None, dev.clone(), fid, Arc::new(protocol.clone())),
+        }
+    }
+}
+
+impl VfsOps for _9pFileSystem {
+    fn mount(&self, _path: &str, mount_point: VfsNodeRef) -> VfsResult {
+        if let Some(parent) = mount_point.parent() {
+            self.root.set_parent(Some(self.parent.call_once(|| parent)));
+        } else {
+            self.root.set_parent(None);
+        }
+        Ok(())
+    }
+
+    fn root_dir(&self) -> VfsNodeRef {
+        self.root.clone()
+    }
+}
+
+/// The directory node in the 9P filesystem.
+///
+/// It implements [`axfs_vfs::VfsNodeOps`].
+pub struct DirNode {
+    inner: Arc<RwLock<Drv9pOps>>,
+    this: Weak<DirNode>,
+    fid: Arc<u32>,
+    protocol: Arc<String>,
+    parent: RwLock<Weak<dyn VfsNodeOps>>,
+    children: RwLock<BTreeMap<String, VfsNodeRef>>,
+}
+
+impl DirNode {
+    pub(super) fn new(
+        parent: Option<Weak<dyn VfsNodeOps>>,
+        dev: Arc<RwLock<Drv9pOps>>,
+        fid: u32,
+        protocol: Arc<String>,
+    ) -> Arc<Self> {
+        if *protocol == "9P2000.L" {
+            match dev.write().l_topen(fid, 0x00) {
+                Ok(_) => {}
+                Err(errcode) => {
+                    error!("9pfs open failed! error code: {}", errcode);
+                }
+            }
+        } else if *protocol == "9P2000.u" {
+            match dev.write().topen(fid, 0x00) {
+                Ok(_) => {}
+                Err(errcode) => {
+                    error!("9pfs open failed! error code: {}", errcode);
+                }
+            }
+        } else {
+            error!("9pfs open failed! Unsupported protocol version");
+        }
+
+        Arc::new_cyclic(|this| Self {
+            inner: dev,
+            this: this.clone(),
+            fid: Arc::new(fid),
+            protocol,
+            parent: RwLock::new(parent.unwrap_or_else(|| Weak::<Self>::new())),
+            children: RwLock::new(BTreeMap::new()),
+        })
+    }
+
+    pub(super) fn set_parent(&self, parent: Option<&VfsNodeRef>) {
+        *self.parent.write() = parent.map_or(Weak::<Self>::new() as _, Arc::downgrade);
+    }
+
+    /// Checks whether a node with the given name exists in this directory.
+    pub fn exist(&self, name: &str) -> bool {
+        debug!("finding if {} exists", name);
+        match self.read_nodes() {
+            Ok(map) => map.contains_key(name),
+            Err(_) => false,
+        }
+    }
+
+    /// Creates a new node with the given name and type in this directory.
+    pub fn create_node(&self, name: &str, ty: VfsNodeType) -> VfsResult {
+        if self.exist(name) {
+            error!("AlreadyExists {}", name);
+            return Err(VfsError::AlreadyExists);
+        }
+        let fid = match self.inner.write().get_fid() {
+            Some(id) => id,
+            None => {
+                error!("No enough fids! Check fid_MAX constrant or fid leaky.");
+                0xff_ff_ff_ff
+            }
+        };
+        match ty {
+            VfsNodeType::File => {
+                handle_result!(
+                    self.inner.write().twalk(*self.fid, fid, 0, &[]),
+                    "9pfs twalk failed! error code: {}"
+                );
+                if *self.protocol == "9P2000.L" {
+                    handle_result!(
+                        self.inner.write().l_tcreate(fid, name, 0x02, 0o100644, 500),
+                        "9pfs l_create failed! error code: {}"
+                    );
+                } else if *self.protocol == "9P2000.u" {
+                    handle_result!(
+                        self.inner.write().u_tcreate(fid, name, 0o777, 0o02, ""),
+                        "9pfs create failed! error code: {}"
+                    );
+                } else {
+                    return Err(VfsError::Unsupported);
+                }
+            }
+            VfsNodeType::Dir => {
+                handle_result!(
+                    self.inner.write().tmkdir(*self.fid, name, 0o40755, 500),
+                    "9pfs mkdir failed! error code: {}"
+                );
+                handle_result!(
+                    self.inner.write().twalk(*self.fid, fid, 1, &[&name]),
+                    "9pfs twalk failed! error code: {}"
+                );
+            }
+            _ => return Err(VfsError::Unsupported),
+        }
+
+        handle_result!(
+            self.inner.write().tclunk(fid),
+            "9pfs tclunk failed! error code: {}"
+        );
+        self.inner.write().recycle_fid(fid);
+
+        Ok(())
+    }
+
+    /// Removes a node by the given name in this directory.
+    pub fn remove_node(&self, name: &str) -> VfsResult {
+        if self.exist(name) {
+            let fid = match self.inner.write().get_fid() {
+                Some(id) => id,
+                None => {
+                    error!("No enough fids! Check fid_MAX constrant or fid leaky.");
+                    0xff_ff_ff_ff
+                }
+            };
+            handle_result!(
+                self.inner.write().twalk(*self.fid, fid, 1, &[name]),
+                "9pfs twalk failed! error code: {}"
+            );
+            handle_result!(
+                self.inner.write().tremove(fid),
+                "9pfs tremove failed! error code: {}"
+            );
+            self.inner.write().recycle_fid(fid);
+            Ok(())
+        } else {
+            Err(VfsError::NotFound)
+        }
+    }
+
+    /// Update nodes from host filesystem
+    fn read_nodes(&self) -> Result<BTreeMap<String, VfsNodeRef>, VfsError> {
+        let mut node_map: BTreeMap<String, VfsNodeRef> = BTreeMap::new();
+        // TODO: the length of dir content can only support as large as MAX_LENGTH.
+        const OFFSET: u64 = 0;
+        const MAX_LENGTH: u32 = 1024;
+        debug!("reading nodes");
+        let dirents = match self.protocol.as_str() {
+            "9P2000.L" => match self.inner.write().treaddir(*self.fid, OFFSET, MAX_LENGTH) {
+                Ok(contents) => contents,
+                Err(errcode) => {
+                    error!("9pfs treaddir failed! error code: {}", errcode);
+                    return Err(VfsError::BadState);
+                }
+            },
+            "9P2000.u" => match self.inner.write().u_treaddir(*self.fid, OFFSET, MAX_LENGTH) {
+                Ok(contents) => contents,
+                Err(errcode) => {
+                    error!("9pfs u_treaddir failed! error code: {}", errcode);
+                    return Err(VfsError::BadState);
+                }
+            },
+            _ => {
+                error!("Unsupport 9P protocol version: {}", *self.protocol);
+                return Err(VfsError::BadState);
+            }
+        };
+
+        for direntry in dirents {
+            let fname = direntry.get_name();
+            if fname.eq("..") || fname.eq(".") {
+                continue;
+            }
+            let ftype = match direntry.get_type() {
+                0o1 => VfsNodeType::Fifo,
+                0o2 => VfsNodeType::CharDevice,
+                0o4 => VfsNodeType::Dir,
+                0o6 => VfsNodeType::BlockDevice,
+                0o10 => VfsNodeType::File,
+                0o12 => VfsNodeType::SymLink,
+                0o14 => VfsNodeType::Socket,
+                _ => {
+                    error!("Unsupported File Type In 9pfs! Using it as File");
+                    VfsNodeType::File
+                }
+            };
+            debug!("9pfs update node {}, type {}", fname, direntry.get_type());
+            let fid = match self.inner.write().get_fid() {
+                Some(id) => id,
+                None => {
+                    error!("No enough fids! Check fid_MAX constrant or fid leaky.");
+                    return Err(VfsError::BadState);
+                }
+            };
+            self.inner
+                .write()
+                .twalk(*self.fid, fid, 1, &[fname])
+                .unwrap();
+            let node: VfsNodeRef = match ftype {
+                VfsNodeType::File => Arc::new(FileNode::new(
+                    self.inner.clone(),
+                    fid,
+                    self.protocol.clone(),
+                )),
+                VfsNodeType::Dir => Self::new(
+                    Some(self.this.clone()),
+                    self.inner.clone(),
+                    fid,
+                    self.protocol.clone(),
+                ),
+                _ => return Err(VfsError::Unsupported),
+            };
+            node_map.insert(fname.into(), node);
+        }
+        Ok(node_map)
+    }
+}
+
+impl Drop for DirNode {
+    fn drop(&mut self) {
+        // pay attention to AA-deadlock
+        let result = self.inner.write().tclunk(*self.fid);
+        match result {
+            Ok(_) => {
+                self.inner.write().recycle_fid(*self.fid);
+            }
+            Err(_) => {
+                error!("9pfs drop failed! It may cause fid leaky problem.")
+            }
+        }
+    }
+}
+
+impl VfsNodeOps for DirNode {
+    fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
+        if *self.protocol == "9P2000.L" {
+            let resp = self.inner.write().tgetattr(*self.fid, 0x3fff_u64);
+            match resp {
+                Ok(attr) => Ok(VfsNodeAttr::new_dir(attr.get_size(), attr.get_blk_num())),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else if *self.protocol == "9P2000.u" {
+            let resp = self.inner.write().tstat(*self.fid);
+            match resp {
+                Ok(stat) => Ok(VfsNodeAttr::new_dir(stat.get_length(), stat.get_blk_num())),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else {
+            Err(VfsError::Unsupported)
+        }
+    }
+
+    fn parent(&self) -> Option<VfsNodeRef> {
+        self.parent.read().upgrade()
+    }
+
+    /// for 9p filesystem's directory, lookup() will return node in 9p if path existing in both 9p and mounted_map.
+    fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
+        let (name, rest) = split_path(path);
+        debug!("9pfs lookup:{}, {:?}", name, rest);
+        let _9p_map = match self.read_nodes() {
+            Ok(contents) => contents,
+            Err(errcode) => {
+                error!("9pfs read_nodes failed! error code = {}", errcode);
+                return Err(VfsError::Unsupported);
+            }
+        };
+
+        // find file in 9p host first, and then find in host if failed
+        let node = match _9p_map.get(name) {
+            Some(node) => node.clone(),
+            None => {
+                debug!("find no {:?} in 9p dir", name);
+                match name {
+                    "" | "." => Ok(self.clone() as VfsNodeRef),
+                    ".." => self.parent().ok_or(VfsError::NotFound),
+                    _ => self
+                        .children
+                        .read()
+                        .get(name)
+                        .cloned()
+                        .ok_or(VfsError::NotFound),
+                }?
+            }
+        };
+
+        if let Some(rest) = rest {
+            node.lookup(rest)
+        } else {
+            Ok(node)
+        }
+    }
+
+    fn read_dir(&self, start_idx: usize, dirents: &mut [VfsDirEntry]) -> VfsResult<usize> {
+        debug!("9pfs reading dirents");
+        let _9p_map = match self.read_nodes() {
+            Ok(contents) => contents,
+            Err(errcode) => {
+                error!("9pfs read_nodes failed! error code = {}", errcode);
+                return Err(VfsError::BadState);
+            }
+        };
+        let children: spin::RwLockReadGuard<'_, BTreeMap<String, Arc<dyn VfsNodeOps>>> =
+            self.children.read();
+
+        // merge mounted tree with 9p's node tree.
+        let mut children = children
+            .iter()
+            .chain(_9p_map.iter())
+            .skip(start_idx.max(2) - 2);
+
+        for (i, ent) in dirents.iter_mut().enumerate() {
+            match i + start_idx {
+                0 => *ent = VfsDirEntry::new(".", VfsNodeType::Dir),
+                1 => *ent = VfsDirEntry::new("..", VfsNodeType::Dir),
+                _ => {
+                    if let Some((name, node)) = children.next() {
+                        let attr = node.get_attr();
+                        let file_type = match attr {
+                            Ok(attr) => attr.file_type(),
+                            Err(ecode) => {
+                                error!("get [{}] attribute failed, error code:{}.", name, ecode);
+                                continue;
+                            }
+                        };
+                        *ent = VfsDirEntry::new(name, file_type);
+                    } else {
+                        return Ok(i);
+                    }
+                }
+            }
+        }
+        Ok(dirents.len())
+    }
+
+    fn create(&self, path: &str, ty: VfsNodeType) -> VfsResult {
+        debug!("create {:?} at 9pfs: {}", ty, path);
+        let (name, rest) = split_path(path);
+        if let Some(rest) = rest {
+            match name {
+                "" | "." => self.create(rest, ty),
+                ".." => self.parent().ok_or(VfsError::NotFound)?.create(rest, ty),
+                _ => {
+                    let subdir = self
+                        .children
+                        .read()
+                        .get(name)
+                        .ok_or(VfsError::NotFound)?
+                        .clone();
+                    subdir.create(rest, ty)
+                }
+            }
+        } else if name.is_empty() || name == "." || name == ".." {
+            Ok(()) // already exists
+        } else {
+            self.create_node(name, ty)
+        }
+    }
+
+    fn remove(&self, path: &str) -> VfsResult {
+        debug!("remove at 9pfs: {}", path);
+        let (name, rest) = split_path(path);
+        if let Some(rest) = rest {
+            match name {
+                "" | "." => self.remove(rest),
+                ".." => self.parent().ok_or(VfsError::NotFound)?.remove(rest),
+                _ => {
+                    let subdir = match self.read_nodes() {
+                        Ok(contents) => contents.get(name).ok_or(VfsError::NotFound)?.clone(),
+                        Err(errcode) => {
+                            error!("9pfs read_nodes failed! error code = {}", errcode);
+                            return Err(VfsError::BadState);
+                        }
+                    };
+                    subdir.remove(rest)
+                }
+            }
+        } else if name.is_empty() || name == "." || name == ".." {
+            Err(VfsError::InvalidInput) // remove '.' or '..
+        } else {
+            self.remove_node(name)
+        }
+    }
+
+    axfs_vfs::impl_vfs_dir_default! {}
+}
+
+fn split_path(path: &str) -> (&str, Option<&str>) {
+    let trimmed_path = path.trim_start_matches('/');
+    trimmed_path.find('/').map_or((trimmed_path, None), |n| {
+        (&trimmed_path[..n], Some(&trimmed_path[n + 1..]))
+    })
+}
+
+/// The file node in the 9P filesystem.
+///
+/// It implements [`axfs_vfs::VfsNodeOps`].
+/// Note: Pay attention to AA-deadlock in inner.
+pub struct FileNode {
+    inner: Arc<RwLock<Drv9pOps>>,
+    fid: Arc<u32>,
+    protocol: Arc<String>,
+}
+
+impl FileNode {
+    pub(super) fn new(dev: Arc<RwLock<Drv9pOps>>, fid: u32, protocol: Arc<String>) -> Self {
+        const OPEN_FLAG: u32 = 0x02;
+        if *protocol == "9P2000.L" {
+            handle_result!(
+                dev.write().l_topen(fid, OPEN_FLAG),
+                "9pfs l_topen failed! error code: {}"
+            );
+        } else if *protocol == "9P2000.u" {
+            handle_result!(
+                dev.write().topen(fid, OPEN_FLAG as u8),
+                "9pfs topen failed! error code: {}"
+            );
+        }
+        Self {
+            inner: dev,
+            fid: Arc::new(fid),
+            protocol,
+        }
+    }
+}
+
+impl Drop for FileNode {
+    fn drop(&mut self) {
+        // pay attention to AA-deadlock
+        let result = self.inner.write().tclunk(*self.fid);
+        match result {
+            Ok(_) => {
+                self.inner.write().recycle_fid(*self.fid);
+            }
+            Err(_) => {
+                error!("9pfs drop failed! It may cause fid leaky problem.")
+            }
+        }
+    }
+}
+
+impl VfsNodeOps for FileNode {
+    impl_vfs_non_dir_default! {}
+    /// Get the attributes of the node.
+    fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
+        if *self.protocol == "9P2000.L" {
+            let resp = self.inner.write().tgetattr(*self.fid, 0x3fff_u64);
+            match resp {
+                Ok(attr) => Ok(VfsNodeAttr::new_file(attr.get_size(), attr.get_blk_num())),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else if *self.protocol == "9P2000.u" {
+            let resp = self.inner.write().tstat(*self.fid);
+            match resp {
+                Ok(stat) => Ok(VfsNodeAttr::new_file(stat.get_length(), stat.get_blk_num())),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else {
+            Err(VfsError::Unsupported)
+        }
+    }
+
+    /// Truncate the file to the given size.
+    fn truncate(&self, size: u64) -> VfsResult {
+        debug!("9pfs truncating, size:{}", size);
+        if *self.protocol == "9P2000.L" {
+            let mut attr = drv::FileAttr::new();
+            attr.set_size(size);
+            match self.inner.write().tsetattr(*self.fid, attr) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else if *self.protocol == "9P2000.u" {
+            let resp = self.inner.write().tstat(*self.fid);
+            let mut stat = match resp {
+                Ok(state) => state,
+                Err(_) => return Err(VfsError::BadState),
+            };
+            stat.set_length(size);
+            match self.inner.write().twstat(*self.fid, stat) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(VfsError::BadState),
+            }
+        } else {
+            error!("{} is not supported", self.protocol);
+            Err(VfsError::Unsupported)
+        }
+    }
+
+    /// Read data from the file at the given offset.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        let mut dev = self.inner.write();
+        match dev.tread(*self.fid, offset, buf.len() as u32) {
+            Ok(content) => {
+                // should be more effient
+                for (i, byte) in content.iter().enumerate() {
+                    buf[i] = *byte;
+                }
+                Ok(content.len())
+            }
+            Err(_) => Err(VfsError::BadState),
+        }
+    }
+
+    /// Write data to the file at the given offset.
+    fn write_at(&self, offset: u64, buf: &[u8]) -> VfsResult<usize> {
+        let mut dev = self.inner.write();
+        match dev.twrite(*self.fid, offset, buf) {
+            Ok(_) => Ok(buf.len()),
+            Err(_) => Err(VfsError::BadState),
+        }
+    }
+
+    /// Flush the file, synchronize the data to disk.
+    fn fsync(&self) -> VfsResult {
+        let mut dev = self.inner.write();
+        match dev.tfsync(*self.fid) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(VfsError::BadState),
+        }
+    }
+}

--- a/modules/ax9p/src/lib.rs
+++ b/modules/ax9p/src/lib.rs
@@ -1,0 +1,95 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+//! [RukOS](https://github.com/syswonder/rukos) 9p module.
+//!
+//! Implement `net-9p` and `virtio-9p`
+//! Shouldn't mount file or directory with the same path as file or directory in 9P host
+//! Or lookup() will only return mounted filesystem node.
+
+#![cfg_attr(all(not(test), not(doc)), no_std)]
+#![feature(doc_auto_cfg)]
+#![feature(ip_in_core)]
+#![cfg(any(feature = "virtio-9p", feature = "net-9p"))]
+
+#[doc(no_inline)]
+extern crate alloc;
+extern crate log;
+
+mod drv;
+mod fs;
+#[cfg(feature = "net-9p")]
+mod netdev;
+
+use alloc::sync::Arc;
+use axfs::MountPoint;
+use log::*;
+use spin::RwLock;
+
+#[cfg(feature = "virtio-9p")]
+use axdriver::{prelude::*, AxDeviceContainer};
+#[cfg(feature = "net-9p")]
+use {
+    alloc::{boxed::Box, vec::Vec},
+    core::option::Option::Some,
+    driver_common::BaseDriverOps,
+};
+
+#[cfg(feature = "virtio-9p")]
+/// Initializes filesystems by 9pfs devices.
+pub fn init_virtio_9pfs(
+    mut v9p_devs: AxDeviceContainer<Ax9pDevice>,
+    aname: &str,
+    protocol: &str,
+) -> MountPoint {
+    info!("Initialize virtio 9pfs...");
+
+    let v9p = v9p_devs.take_one().expect("No 9pfs device found!");
+    info!("  use 9pfs device 0: {:?}", v9p.device_name());
+
+    let v9p_driver = self::drv::Drv9pOps::new(v9p);
+    let v9p_fs = self::fs::_9pFileSystem::new(Arc::new(RwLock::new(v9p_driver)), aname, protocol);
+
+    MountPoint::new("/v9fs", Arc::new(v9p_fs))
+}
+
+#[cfg(feature = "net-9p")]
+/// Initializes filesystems by 9pfs devices.
+pub fn init_net_9pfs(ip_port: &str, aname: &str, protocol: &str) -> MountPoint {
+    info!("Initialize net 9pfs...");
+
+    let net9p = match parse_address(ip_port) {
+        Some((ip, port)) => self::netdev::Net9pDev::new(&ip, port),
+        None => self::netdev::Net9pDev::new(&[127, 0, 0, 1], 564_u16), // use 127.0.0.1:564 in defealt
+    };
+    info!("use 9pfs device 0: {:?}", net9p.device_name());
+
+    // Enabling `dyn` feature in axdriver, pub type Ax9pDevice = Box<dyn _9pDriverOps>;
+    // TODO: consider a more elegant implement.
+    let net9p_driver = self::drv::Drv9pOps::new(Box::new(net9p));
+    let n9p_fs = self::fs::_9pFileSystem::new(Arc::new(RwLock::new(net9p_driver)), aname, protocol);
+
+    MountPoint::new("/n9fs", Arc::new(n9p_fs))
+}
+
+#[cfg(feature = "net-9p")]
+fn parse_address(s: &str) -> Option<(Vec<u8>, u16)> {
+    let mut parts = s.split(':');
+    if let (Some(address), Some(port)) = (parts.next(), parts.next()) {
+        let parsed_address: Result<Vec<u8>, _> =
+            address.split('.').map(|part| part.parse::<u8>()).collect();
+
+        if let Ok(address_parts) = parsed_address {
+            if let Ok(port) = port.parse::<u16>() {
+                return Some((address_parts, port));
+            }
+        }
+    }
+    None
+}

--- a/modules/ax9p/src/netdev.rs
+++ b/modules/ax9p/src/netdev.rs
@@ -1,0 +1,84 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Rukos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+use axnet::TcpSocket;
+use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+use driver_9p::_9pDriverOps;
+use driver_common::{BaseDriverOps, DeviceType};
+use log::*;
+
+pub struct Net9pDev {
+    socket: TcpSocket,
+    srv_addr: SocketAddr,
+}
+
+impl Net9pDev {
+    pub fn new(ip: &[u8], port: u16) -> Self {
+        let ip_addr = match ip.len() {
+            4 => IpAddr::V4(Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3])),
+            _ => {
+                error!("Unsupport IP address: {:?}, using 0.0.0.0 instead", ip);
+                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+            }
+        };
+        Self {
+            socket: TcpSocket::new(),
+            srv_addr: SocketAddr::new(ip_addr, port),
+        }
+    }
+}
+
+impl BaseDriverOps for Net9pDev {
+    fn device_name(&self) -> &str {
+        "net-9p"
+    }
+
+    fn device_type(&self) -> DeviceType {
+        DeviceType::_9P
+    }
+}
+
+impl _9pDriverOps for Net9pDev {
+    // initialize self(e.g. setup TCP connection)
+    fn init(&self) -> Result<(), u8> {
+        info!("9P client connecting to {:?}", self.srv_addr);
+        match self.socket.connect(self.srv_addr) {
+            Ok(_) => {
+                info!("net9p connected successfully");
+                Ok(())
+            }
+            Err(_) => {
+                error!("net9p connected failed");
+                Err(0)
+            }
+        }
+    }
+
+    // send bytes of inputs as request and receive  get answer in outputs
+    fn send_with_recv(&mut self, inputs: &[u8], outputs: &mut [u8]) -> Result<u32, u8> {
+        match self.socket.send(inputs) {
+            Ok(length) => {
+                debug!("net9p send successfully,length = {}", length);
+            }
+            Err(_) => {
+                error!("net9p send failed");
+                return Err(0);
+            }
+        }
+        match self.socket.recv(outputs) {
+            Ok(length) => {
+                debug!("net9p recv successfully,length = {}", length);
+                Ok(length as u32)
+            }
+            Err(_) => {
+                error!("net9p recv failed");
+                Err(0)
+            }
+        }
+    }
+}

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -16,6 +16,7 @@ bus-pci = ["dep:driver_pci", "dep:axhal", "dep:axconfig"]
 net = ["driver_net"]
 block = ["driver_block"]
 display = ["driver_display"]
+_9p = ["driver_9p"]
 
 # Enabled by features `virtio-*`
 virtio = ["driver_virtio", "dep:axalloc", "dep:axhal", "dep:axconfig"]
@@ -24,6 +25,7 @@ virtio = ["driver_virtio", "dep:axalloc", "dep:axhal", "dep:axconfig"]
 virtio-blk = ["block", "virtio", "driver_virtio/block"]
 virtio-net = ["net", "virtio", "driver_virtio/net"]
 virtio-gpu = ["display", "virtio", "driver_virtio/gpu"]
+virtio-9p = ["_9p","virtio", "driver_virtio/v9p"]
 ramdisk = ["block", "driver_block/ramdisk"]
 bcm2835-sdhci = ["block", "driver_block/bcm2835-sdhci"]
 ixgbe = ["net", "driver_net/ixgbe", "dep:axalloc", "dep:axhal"]
@@ -38,6 +40,7 @@ driver_common = { path = "../../crates/driver_common" }
 driver_block = { path = "../../crates/driver_block", optional = true }
 driver_net = { path = "../../crates/driver_net", optional = true }
 driver_display = { path = "../../crates/driver_display", optional = true }
+driver_9p = { path = "../../crates/driver_9p", optional = true }
 driver_pci = { path = "../../crates/driver_pci", optional = true }
 driver_virtio = { path = "../../crates/driver_virtio", optional = true }
 axalloc = { path = "../axalloc", optional = true }

--- a/modules/axdriver/build.rs
+++ b/modules/axdriver/build.rs
@@ -10,13 +10,20 @@
 const NET_DEV_FEATURES: &[&str] = &["ixgbe", "virtio-net"];
 const BLOCK_DEV_FEATURES: &[&str] = &["ramdisk", "bcm2835-sdhci", "virtio-blk"];
 const DISPLAY_DEV_FEATURES: &[&str] = &["virtio-gpu"];
+const _9P_DEV_FEATURES: &[&str] = &["virtio-9p"];
 
 fn has_feature(feature: &str) -> bool {
-    std::env::var(format!(
+    let ret = std::env::var(format!(
         "CARGO_FEATURE_{}",
         feature.to_uppercase().replace('-', "_")
     ))
-    .is_ok()
+    .is_ok();
+    println!(
+        "CARGO_FEATURE_{}   {}",
+        feature.to_uppercase().replace('-', "_"),
+        ret
+    );
+    ret
 }
 
 fn enable_cfg(key: &str, value: &str) {
@@ -37,6 +44,7 @@ fn main() {
         ("net", NET_DEV_FEATURES),
         ("block", BLOCK_DEV_FEATURES),
         ("display", DISPLAY_DEV_FEATURES),
+        ("_9p", _9P_DEV_FEATURES),
     ] {
         if !has_feature(dev_kind) {
             continue;

--- a/modules/axdriver/src/drivers.rs
+++ b/modules/axdriver/src/drivers.rs
@@ -60,6 +60,12 @@ register_display_driver!(
     <virtio::VirtIoGpu as VirtIoDevMeta>::Device
 );
 
+#[cfg(_9p_dev = "virtio-9p")]
+register_9p_driver!(
+    <virtio::VirtIo9p as VirtIoDevMeta>::Driver,
+    <virtio::VirtIo9p as VirtIoDevMeta>::Device
+);
+
 cfg_if::cfg_if! {
     if #[cfg(block_dev = "ramdisk")] {
         pub struct RamDiskDriver;

--- a/modules/axdriver/src/dummy.rs
+++ b/modules/axdriver/src/dummy.rs
@@ -109,3 +109,31 @@ cfg_if! {
         }
     }
 }
+
+cfg_if! {
+    if #[cfg(_9p_dev = "dummy")] {
+        pub struct Dummy9pDev;
+        pub struct Dummy9pDriver;
+        register_9p_driver!(Dummy9pDriver, Dummy9pDev);
+
+        impl BaseDriverOps for Dummy9pDev {
+            fn device_type(&self) -> DeviceType {
+                DeviceType::_9P
+            }
+            fn device_name(&self) -> &str {
+                "dummy-9p"
+            }
+        }
+
+        impl _9pDriverOps for Dummy9pDev {
+            fn init(&self) -> Result<(), u8>{
+                Err(0)
+            }
+
+            #[allow(unused_variables)]
+            fn send_with_recv(&mut self, inputs: &[u8], outputs: &mut [u8]) -> Result<u32, u8>{
+                Err(0)
+            }
+        }
+    }
+}

--- a/modules/axdriver/src/lib.rs
+++ b/modules/axdriver/src/lib.rs
@@ -43,6 +43,7 @@
 //! | Block | `virtio-blk` | VirtIO block device |
 //! | Network | `virtio-net` | VirtIO network device |
 //! | Display | `virtio-gpu` | VirtIO graphics device |
+//! | 9p | `virtio-9p`、`net-9p` | VirtIO/Net 9pfs device |
 //!
 //! # Other Cargo Features
 //!
@@ -57,6 +58,7 @@
 //!    features, a dummy struct is used for [`AxNetDevice`].
 //! - `block`: use block storage devices. Similar to the `net` feature.
 //! - `display`: use graphics display devices. Similar to the `net` feature.
+//! - `_9p`: use 9pfs devices. Similar to the `net` feature.
 //!
 //! [`VirtioNetDev`]: driver_virtio::VirtIoNetDev
 //! [`Box<dyn NetDriverOps>`]: driver_net::NetDriverOps
@@ -93,6 +95,8 @@ pub mod prelude;
 use self::prelude::*;
 pub use self::structs::{AxDeviceContainer, AxDeviceEnum};
 
+#[cfg(feature = "_9p")]
+pub use self::structs::Ax9pDevice;
 #[cfg(feature = "block")]
 pub use self::structs::AxBlockDevice;
 #[cfg(feature = "display")]
@@ -112,6 +116,9 @@ pub struct AllDevices {
     /// All graphics device drivers.
     #[cfg(feature = "display")]
     pub display: AxDeviceContainer<AxDisplayDevice>,
+    /// All 9p device drivers.
+    #[cfg(feature = "_9p")]
+    pub _9p: AxDeviceContainer<Ax9pDevice>,
 }
 
 impl AllDevices {
@@ -152,6 +159,8 @@ impl AllDevices {
             AxDeviceEnum::Block(dev) => self.block.push(dev),
             #[cfg(feature = "display")]
             AxDeviceEnum::Display(dev) => self.display.push(dev),
+            #[cfg(feature = "_9p")]
+            AxDeviceEnum::_9P(dev) => self._9p.push(dev),
         }
     }
 }
@@ -186,6 +195,14 @@ pub fn init_drivers() -> AllDevices {
         for (i, dev) in all_devs.display.iter().enumerate() {
             assert_eq!(dev.device_type(), DeviceType::Display);
             debug!("  graphics device {}: {:?}", i, dev.device_name());
+        }
+    }
+    #[cfg(feature = "_9p")]
+    {
+        debug!("number of 9p devices: {}", all_devs._9p.len());
+        for (i, dev) in all_devs._9p.iter().enumerate() {
+            assert_eq!(dev.device_type(), DeviceType::_9P);
+            debug!("  9p device {}: {:?}", i, dev.device_name());
         }
     }
 

--- a/modules/axdriver/src/macros.rs
+++ b/modules/axdriver/src/macros.rs
@@ -35,6 +35,14 @@ macro_rules! register_display_driver {
     };
 }
 
+macro_rules! register_9p_driver {
+    ($driver_type:ty, $device_type:ty) => {
+        /// The unified type of the NIC devices.
+        #[cfg(not(feature = "dyn"))]
+        pub type Ax9pDevice = $device_type;
+    };
+}
+
 macro_rules! for_each_drivers {
     (type $drv_type:ident, $code:block) => {{
         #[allow(unused_imports)]
@@ -56,6 +64,11 @@ macro_rules! for_each_drivers {
         #[cfg(display_dev = "virtio-gpu")]
         {
             type $drv_type = <virtio::VirtIoGpu as VirtIoDevMeta>::Driver;
+            $code
+        }
+        #[cfg(_9p_dev = "virtio-9p")]
+        {
+            type $drv_type = <virtio::VirtIo9p as VirtIoDevMeta>::Driver;
             $code
         }
         #[cfg(block_dev = "ramdisk")]

--- a/modules/axdriver/src/prelude.rs
+++ b/modules/axdriver/src/prelude.rs
@@ -11,6 +11,8 @@
 
 pub use driver_common::{BaseDriverOps, DevError, DevResult, DeviceType};
 
+#[cfg(feature = "_9p")]
+pub use {crate::structs::Ax9pDevice, driver_9p::_9pDriverOps};
 #[cfg(feature = "block")]
 pub use {crate::structs::AxBlockDevice, driver_block::BlockDriverOps};
 #[cfg(feature = "display")]

--- a/modules/axdriver/src/structs/dyn.rs
+++ b/modules/axdriver/src/structs/dyn.rs
@@ -21,6 +21,9 @@ pub type AxBlockDevice = Box<dyn BlockDriverOps>;
 /// The unified type of the graphics display devices.
 #[cfg(feature = "display")]
 pub type AxDisplayDevice = Box<dyn DisplayDriverOps>;
+/// The unified type of the 9p devices.
+#[cfg(feature = "_9p")]
+pub type Ax9pDevice = Box<dyn _9pDriverOps>;
 
 impl super::AxDeviceEnum {
     /// Constructs a network device.
@@ -39,6 +42,12 @@ impl super::AxDeviceEnum {
     #[cfg(feature = "display")]
     pub fn from_display(dev: impl DisplayDriverOps + 'static) -> Self {
         Self::Display(Box::new(dev))
+    }
+
+    /// Constructs a 9p device.
+    #[cfg(feature = "_9p")]
+    pub fn from_9p(dev: impl _9pDriverOps + 'static) -> Self {
+        Self::_9P(Box::new(dev))
     }
 }
 

--- a/modules/axdriver/src/structs/mod.rs
+++ b/modules/axdriver/src/structs/mod.rs
@@ -27,6 +27,9 @@ pub enum AxDeviceEnum {
     /// Graphic display device.
     #[cfg(feature = "display")]
     Display(AxDisplayDevice),
+    /// Plan-9 protocol device.
+    #[cfg(feature = "_9p")]
+    _9P(Ax9pDevice),
 }
 
 impl BaseDriverOps for AxDeviceEnum {
@@ -40,6 +43,8 @@ impl BaseDriverOps for AxDeviceEnum {
             Self::Block(_) => DeviceType::Block,
             #[cfg(feature = "display")]
             Self::Display(_) => DeviceType::Display,
+            #[cfg(feature = "_9p")]
+            Self::_9P(_) => DeviceType::_9P,
             _ => unreachable!(),
         }
     }
@@ -54,6 +59,8 @@ impl BaseDriverOps for AxDeviceEnum {
             Self::Block(dev) => dev.device_name(),
             #[cfg(feature = "display")]
             Self::Display(dev) => dev.device_name(),
+            #[cfg(feature = "_9p")]
+            Self::_9P(dev) => dev.device_name(),
             _ => unreachable!(),
         }
     }

--- a/modules/axdriver/src/structs/static.rs
+++ b/modules/axdriver/src/structs/static.rs
@@ -7,6 +7,8 @@
  *   See the Mulan PSL v2 for more details.
  */
 
+#[cfg(feature = "_9p")]
+pub use crate::drivers::Ax9pDevice;
 #[cfg(feature = "block")]
 pub use crate::drivers::AxBlockDevice;
 #[cfg(feature = "display")]
@@ -31,6 +33,12 @@ impl super::AxDeviceEnum {
     #[cfg(feature = "display")]
     pub const fn from_display(dev: AxDisplayDevice) -> Self {
         Self::Display(dev)
+    }
+
+    /// Constructs a display device.
+    #[cfg(feature = "_9p")]
+    pub const fn from_9p(dev: Ax9pDevice) -> Self {
+        Self::_9P(dev)
     }
 }
 

--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -82,6 +82,21 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(_9p_dev = "virtio-9p")] {
+        pub struct VirtIo9p;
+
+        impl VirtIoDevMeta for VirtIo9p {
+            const DEVICE_TYPE: DeviceType = DeviceType::_9P;
+            type Device = driver_virtio::VirtIo9pDev<VirtIoHalImpl, VirtIoTransport>;
+
+            fn try_new(transport: VirtIoTransport) -> DevResult<AxDeviceEnum> {
+                Ok(AxDeviceEnum::from_9p(Self::Device::try_new(transport)?))
+            }
+        }
+    }
+}
+
 /// A common driver for all VirtIO devices that implements [`DriverProbe`].
 pub struct VirtIoDriver<D: VirtIoDevMeta + ?Sized>(PhantomData<D>);
 
@@ -123,6 +138,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
             (DeviceType::Net, 0x1000) | (DeviceType::Net, 0x1040) => {}
             (DeviceType::Block, 0x1001) | (DeviceType::Block, 0x1041) => {}
             (DeviceType::Display, 0x1050) => {}
+            (DeviceType::_9P, 0x1009) => {}
             _ => return None,
         }
 

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -43,13 +43,64 @@ mod root;
 pub mod api;
 pub mod fops;
 
+use alloc::vec::Vec;
+
 use axdriver::{prelude::*, AxDeviceContainer};
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "myfs")] {
+    } else if #[cfg(feature = "fatfs")] {
+        use lazy_init::LazyInit;
+        use alloc::sync::Arc;
+    }
+}
+
+pub use root::MountPoint;
+
 /// Initializes filesystems by block devices.
-pub fn init_filesystems(mut blk_devs: AxDeviceContainer<AxBlockDevice>) {
+pub fn init_blkfs(mut blk_devs: AxDeviceContainer<AxBlockDevice>) -> MountPoint {
     info!("Initialize filesystems...");
 
     let dev = blk_devs.take_one().expect("No block device found!");
     info!("  use block device 0: {:?}", dev.device_name());
-    self::root::init_rootfs(self::dev::Disk::new(dev));
+
+    let disk = self::dev::Disk::new(dev);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "myfs")] { // override the default filesystem
+            let blk_fs = fs::myfs::new_myfs(disk);
+        } else if #[cfg(feature = "fatfs")] {
+            static FAT_FS: LazyInit<Arc<fs::fatfs::FatFileSystem>> = LazyInit::new();
+            FAT_FS.init_by(Arc::new(fs::fatfs::FatFileSystem::new(disk)));
+            FAT_FS.init();
+            let blk_fs = FAT_FS.clone();
+        }
+    }
+
+    MountPoint::new("/", blk_fs)
+}
+
+/// Initializes common filesystems.
+pub fn prepare_commonfs(mount_points: &mut Vec<self::root::MountPoint>) {
+    #[cfg(feature = "devfs")]
+    let mount_point = MountPoint::new("/dev", mounts::devfs());
+    mount_points.push(mount_point);
+
+    #[cfg(feature = "ramfs")]
+    let mount_point = MountPoint::new("/tmp", mounts::ramfs());
+    mount_points.push(mount_point);
+
+    // Mount another ramfs as procfs
+    #[cfg(feature = "procfs")]
+    let mount_point = MountPoint::new("/proc", mounts::procfs().unwrap());
+    mount_points.push(mount_point);
+
+    // Mount another ramfs as sysfs
+    #[cfg(feature = "sysfs")]
+    let mount_point = MountPoint::new("/sys", mounts::sysfs().unwrap());
+    mount_points.push(mount_point);
+}
+
+/// Initializes root filesystems.
+pub fn init_filesystems(mount_points: Vec<self::root::MountPoint>) {
+    self::root::init_rootfs(mount_points);
 }

--- a/modules/axfs/tests/test_fatfs.rs
+++ b/modules/axfs/tests/test_fatfs.rs
@@ -30,7 +30,14 @@ fn test_fatfs() {
 
     let disk = make_disk().expect("failed to load disk image");
     axtask::init_scheduler(); // call this to use `axsync::Mutex`.
-    axfs::init_filesystems(AxDeviceContainer::from_one(disk));
+                              // By default, mount_points[0] will be rootfs
+    let mut mount_points: Vec<axfs::MountPoint> = Vec::new();
+    // setup and initialize blkfs as one mountpoint for rootfs
+    mount_points.push(axfs::init_blkfs(AxDeviceContainer::from_one(disk)));
+    axfs::prepare_commonfs(&mut mount_points);
+
+    // setup and initialize rootfs
+    axfs::init_filesystems(mount_points);
 
     test_common::test_all();
 }

--- a/modules/axfs/tests/test_ramfs.rs
+++ b/modules/axfs/tests/test_ramfs.rs
@@ -55,7 +55,16 @@ fn test_ramfs() {
     println!("Testing ramfs ...");
 
     axtask::init_scheduler(); // call this to use `axsync::Mutex`.
-    axfs::init_filesystems(AxDeviceContainer::from_one(RamDisk::default())); // dummy disk, actually not used.
+                              // By default, mount_points[0] will be rootfs
+    let mut mount_points: Vec<axfs::MountPoint> = Vec::new();
+    // setup and initialize blkfs as one mountpoint for rootfs
+    mount_points.push(axfs::init_blkfs(AxDeviceContainer::from_one(
+        RamDisk::default(),
+    )));
+    axfs::prepare_commonfs(&mut mount_points);
+
+    // setup and initialize rootfs
+    axfs::init_filesystems(mount_points);
 
     if let Err(e) = create_init_files() {
         log::warn!("failed to create init files: {:?}", e);

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -21,6 +21,8 @@ rtc = ["axhal/rtc"]
 
 multitask = ["axtask/multitask"]
 fs = ["axdriver", "axfs"]
+virtio-9p = ["fs", "ax9p"]
+net-9p = ["fs", "ax9p"]
 net = ["axdriver", "axnet"]
 display = ["axdriver", "axdisplay"]
 signal = []
@@ -33,6 +35,7 @@ axconfig = { path = "../axconfig" }
 axalloc = { path = "../axalloc", optional = true }
 axdriver = { path = "../axdriver", optional = true }
 axfs = { path = "../axfs", optional = true }
+ax9p = { path = "../ax9p", optional = true }
 axnet = { path = "../axnet", optional = true }
 axdisplay = { path = "../axdisplay", optional = true }
 axtask = { path = "../axtask", optional = true }

--- a/scripts/make/qemu.mk
+++ b/scripts/make/qemu.mk
@@ -34,6 +34,10 @@ qemu_args-$(BLK) += \
 qemu_args-$(NET) += \
   -device virtio-net-$(vdev-suffix),netdev=net0
 
+qemu_args-$(V9P) += \
+  -fsdev local,id=myid,path=${V9P_PATH},security_model=none \
+  -device virtio-9p-$(vdev-suffix),fsdev=myid,mount_tag=rootfs
+
 ifeq ($(NET_DEV), user)
   qemu_args-$(NET) += -netdev user,id=net0,hostfwd=tcp::5555-:5555,hostfwd=udp::5555-:5555
 else ifeq ($(NET_DEV), tap)

--- a/ulib/axlibc/c/stdio.c
+++ b/ulib/axlibc/c/stdio.c
@@ -242,10 +242,16 @@ char *fgets(char *restrict s, int n, FILE *restrict f)
         if (read(f->fd, (void *)&c, 1) > 0) {
             if (c != '\n')
                 s[cnt++] = c;
-            else
+            else{
+                s[cnt++] = c;
                 break;
+            }
+                
         } else
             break;
+    }
+    if(cnt==0){
+        return NULL;
     }
     s[cnt] = '\0';
     return s;

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -48,6 +48,8 @@ sched_cfs = ["axfeat/sched_cfs"]
 # File system
 fs = ["arceos_api/fs", "axfeat/fs"]
 myfs = ["arceos_api/myfs", "axfeat/myfs"]
+virtio-9p = ["axfeat/virtio-9p"]
+net-9p = ["axfeat/net-9p"]
 
 # Networking
 net = ["arceos_api/net", "axfeat/net"]


### PR DESCRIPTION
1. Add `ax9p` to module, which implement 9P protocol, including `9P2000.L` and `9P2000.u`.
2. Support new features `virtio-9p` and `net-9p`.
3. Add `virtio-9p` support for redis application.
4. Temporarily fix bugs in axlibc's `fgets()`.