### PR TITLE
fix buffer bugs in 9pfs and add `blkfs` feature

### DIFF
--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -39,7 +39,8 @@ sched_rr = ["axtask/sched_rr", "irq"]
 sched_cfs = ["axtask/sched_cfs", "irq"]
 
 # File system
-fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
+fs = ["alloc", "paging", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
+blkfs = ["axdriver/virtio-blk", "axruntime/blkfs"]
 myfs = ["axfs?/myfs"]
 9pfs = []
 

--- a/apps/c/filetest/features.txt
+++ b/apps/c/filetest/features.txt
@@ -1,3 +1,4 @@
 alloc
 paging
 fs
+blkfs

--- a/apps/c/iperf/features.txt
+++ b/apps/c/iperf/features.txt
@@ -2,5 +2,6 @@ alloc
 paging
 net
 fs
+blkfs
 select
 fp_simd

--- a/apps/c/redis/features.txt
+++ b/apps/c/redis/features.txt
@@ -4,6 +4,7 @@ fp_simd
 irq
 multitask
 fs
+blkfs
 net
 pipe
 epoll

--- a/apps/c/sqlite3/features.txt
+++ b/apps/c/sqlite3/features.txt
@@ -2,3 +2,4 @@ fp_simd
 alloc
 paging
 fs
+blkfs

--- a/apps/fs/shell/Cargo.toml
+++ b/apps/fs/shell/Cargo.toml
@@ -14,4 +14,4 @@ default = []
 axfs_vfs = { path = "../../../crates/axfs_vfs", optional = true }
 axfs_ramfs = { path = "../../../crates/axfs_ramfs", optional = true }
 crate_interface = { path = "../../../crates/crate_interface", optional = true }
-axstd = { path = "../../../ulib/axstd", features = ["alloc", "fs", "virtio-9p"], optional = true }
+axstd = { path = "../../../ulib/axstd", features = ["alloc", "fs","blkfs"], optional = true }

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -57,6 +57,12 @@ cfg_if::cfg_if! {
 
 pub use root::MountPoint;
 
+/// Initialize an empty filesystems by ramfs.
+#[cfg(not(any(feature = "blkfs", feature = "virtio-9p", feature = "net-9p")))]
+pub fn init_tempfs() -> MountPoint {
+    MountPoint::new("/", mounts::ramfs())
+}
+
 /// Initializes filesystems by block devices.
 pub fn init_blkfs(mut blk_devs: AxDeviceContainer<AxBlockDevice>) -> MountPoint {
     info!("Initialize filesystems...");

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -21,6 +21,7 @@ rtc = ["axhal/rtc"]
 
 multitask = ["axtask/multitask"]
 fs = ["axdriver", "axfs"]
+blkfs = ["fs"]
 virtio-9p = ["fs", "ax9p"]
 net-9p = ["fs", "ax9p"]
 net = ["axdriver", "axnet"]

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -193,9 +193,13 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
             // By default, mount_points[0] will be rootfs
             let mut mount_points: Vec<axfs::MountPoint> = Vec::new();
 
+            //setup ramfs as rootfs if no other filesystem can be mounted
+            #[cfg(not(any(feature = "blkfs", feature = "virtio-9p", feature = "net-9p")))]
+            mount_points.push(axfs::init_tempfs());
+
             // setup and initialize blkfs as one mountpoint for rootfs
+            #[cfg(feature = "blkfs")]
             mount_points.push(axfs::init_blkfs(all_devices.block));
-            axfs::prepare_commonfs(&mut mount_points);
 
             // setup and initialize 9pfs as mountpoint
             #[cfg(feature = "virtio-9p")]
@@ -210,6 +214,7 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
                 option_env!("AX_ANAME_9P").unwrap_or(""),
                 option_env!("AX_PROTOCOL_9P").unwrap_or(""),
             ));
+            axfs::prepare_commonfs(&mut mount_points);
 
             // setup and initialize rootfs
             axfs::init_filesystems(mount_points);

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -48,6 +48,7 @@ sched_cfs = ["axfeat/sched_cfs"]
 # File system
 fs = ["arceos_api/fs", "axfeat/fs"]
 myfs = ["arceos_api/myfs", "axfeat/myfs"]
+blkfs = ["axfeat/blkfs"]
 virtio-9p = ["axfeat/virtio-9p"]
 net-9p = ["axfeat/net-9p"]
 


### PR DESCRIPTION
1. Fix 9p buffer bugs in `tread()`,`treaddir()`,`u_treaddir()` and `twrite()`.
2. Add feature `blkfs` to make it possible to mount `9pfs` or ramfs as rootfs.