### PR TITLE
Complete some syscall for musl.

### DIFF
--- a/api/arceos_posix_api/src/imp/fs.rs
+++ b/api/arceos_posix_api/src/imp/fs.rs
@@ -155,10 +155,20 @@ pub fn sys_lseek(fd: c_int, offset: ctypes::off_t, whence: c_int) -> ctypes::off
     })
 }
 
-/// `fsync`
+/// Synchronize a file's in-core state with storage device
+///
+/// TODO
 pub unsafe fn sys_fsync(fd: c_int) -> c_int {
     debug!("sys_fsync <= fd: {}", fd);
     syscall_body!(sys_fsync, Ok(0))
+}
+
+/// Synchronize a file's in-core state with storage device
+///
+/// TODO
+pub unsafe fn sys_fdatasync(fd: c_int) -> c_int {
+    debug!("sys_fdatasync <= fd: {}", fd);
+    syscall_body!(sys_fdatasync, Ok(0))
 }
 
 /// Get the file metadata by `path` and write into `buf`.
@@ -294,6 +304,24 @@ pub fn sys_rename(old: *const c_char, new: *const c_char) -> c_int {
         let new_path = char_ptr_to_str(new)?;
         debug!("sys_rename <= old: {:?}, new: {:?}", old_path, new_path);
         axfs::api::rename(old_path, new_path)?;
+        Ok(0)
+    })
+}
+
+/// Rename at certain directory pointed by `oldfd`
+///
+/// TODO: only support `oldfd`, `newfd` equals to AT_FDCWD
+pub fn sys_renameat(oldfd: c_int, old: *const c_char, newfd: c_int, new: *const c_char) -> c_int {
+    let old_path = char_ptr_to_str(old);
+    let new_path = char_ptr_to_str(new);
+    debug!(
+        "sys_renameat <= oldfd: {}, old: {:?}, newfd: {}, new: {:?}",
+        oldfd, old_path, newfd, new_path
+    );
+    assert_eq!(oldfd, ctypes::AT_FDCWD as c_int);
+    assert_eq!(newfd, ctypes::AT_FDCWD as c_int);
+    syscall_body!(sys_renameat, {
+        axfs::api::rename(old_path?, new_path?)?;
         Ok(0)
     })
 }

--- a/api/arceos_posix_api/src/lib.rs
+++ b/api/arceos_posix_api/src/lib.rs
@@ -45,7 +45,7 @@ pub mod config {
 #[allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals, clippy::upper_case_acronyms, missing_docs)]
 pub mod ctypes;
 
-pub use imp::io::{sys_read, sys_write, sys_writev};
+pub use imp::io::{sys_read, sys_readv, sys_write, sys_writev};
 pub use imp::resources::{sys_getrlimit, sys_prlimit64, sys_setrlimit};
 pub use imp::rt_sig::{sys_rt_sigaction, sys_rt_sigprocmask};
 pub use imp::stat::sys_umask;
@@ -60,8 +60,9 @@ pub use imp::fd_ops::sys_dup3;
 pub use imp::fd_ops::{sys_close, sys_dup, sys_dup2, sys_fcntl};
 #[cfg(feature = "fs")]
 pub use imp::fs::{
-    sys_fstat, sys_fsync, sys_getcwd, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat, sys_newfstatat,
-    sys_open, sys_openat, sys_rename, sys_rmdir, sys_stat, sys_unlink, sys_unlinkat,
+    sys_fdatasync, sys_fstat, sys_fsync, sys_getcwd, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat,
+    sys_newfstatat, sys_open, sys_openat, sys_rename, sys_renameat, sys_rmdir, sys_stat,
+    sys_unlink, sys_unlinkat,
 };
 #[cfg(feature = "epoll")]
 pub use imp::io_mpx::{sys_epoll_create, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait};

--- a/ulib/axmusl/src/syscall/mod.rs
+++ b/ulib/axmusl/src/syscall/mod.rs
@@ -60,6 +60,13 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[2] as c_int,
             ) as _,
             #[cfg(feature = "fs")]
+            SyscallId::RENAMEAT => arceos_posix_api::sys_renameat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as c_int,
+                args[3] as *const core::ffi::c_char,
+            ) as _,
+            #[cfg(feature = "fs")]
             SyscallId::OPENAT => arceos_posix_api::sys_openat(
                 args[0],
                 args[1] as *const core::ffi::c_char,
@@ -88,6 +95,12 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[0] as c_int,
                 args[1] as *mut core::ffi::c_void,
                 args[2],
+            ) as _,
+            #[cfg(feature = "fd")]
+            SyscallId::READV => arceos_posix_api::sys_readv(
+                args[0] as c_int,
+                args[1] as *const ctypes::iovec,
+                args[2] as c_int,
             ) as _,
             #[cfg(feature = "fd")]
             SyscallId::WRITEV => arceos_posix_api::sys_writev(
@@ -126,6 +139,8 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
             }
             #[cfg(feature = "fs")]
             SyscallId::FSYNC => arceos_posix_api::sys_fsync(args[0] as c_int) as _,
+            #[cfg(feature = "fs")]
+            SyscallId::FDATASYNC => arceos_posix_api::sys_fdatasync(args[0] as c_int) as _,
             #[allow(unreachable_code)]
             #[cfg(not(feature = "multitask"))]
             SyscallId::EXIT => arceos_posix_api::sys_exit(args[0] as c_int) as _,

--- a/ulib/axmusl/src/syscall/syscall_id.rs
+++ b/ulib/axmusl/src/syscall/syscall_id.rs
@@ -28,6 +28,8 @@ pub enum SyscallId {
     #[cfg(feature = "fs")]
     UNLINKAT = 35,
     #[cfg(feature = "fs")]
+    RENAMEAT = 38,
+    #[cfg(feature = "fs")]
     OPENAT = 56,
     #[cfg(feature = "fd")]
     CLOSE = 57,
@@ -37,6 +39,8 @@ pub enum SyscallId {
     LSEEK = 62,
     READ = 63,
     WRITE = 64,
+    #[cfg(feature = "fd")]
+    READV = 65,
     #[cfg(feature = "fd")]
     WRITEV = 66,
     #[cfg(feature = "select")]
@@ -49,6 +53,8 @@ pub enum SyscallId {
     FSTAT = 80,
     #[cfg(feature = "fs")]
     FSYNC = 82,
+    #[cfg(feature = "fs")]
+    FDATASYNC = 83,
     EXIT = 93,
     #[cfg(feature = "multitask")]
     SET_TID_ADDRESS = 96,


### PR DESCRIPTION
Add `renameat`, `readv`, `fdatasync` to musl, so that Redis can save data to disk.